### PR TITLE
Remove discourse

### DIFF
--- a/about.html
+++ b/about.html
@@ -78,9 +78,6 @@
         <!--================Work Area =================-->
         <section class="work_area p_120">
           <div class="container">
-            <div class="main_title discourse">
-        			<p> <img src="img/logo_discourse.png"/> Join our official <a href="https://speechbrain.discourse.group">Discourse</a> to discuss with SpeechBrain users coming from all around the world! <img src="img/logo_discourse.png"/></p>
-        		</div>
             <div class="main_title">
               <h2>Community driven</h2>
               <p class="justified large">SpeechBrain has been designed to help researchers and developers.

--- a/contributing.html
+++ b/contributing.html
@@ -78,9 +78,6 @@
         <!--================Work Area =================-->
         <section class="work_area p_120">
           <div class="container">
-            <div class="main_title discourse">
-        			<p> <img src="img/logo_discourse.png"/> Join our official <a href="https://speechbrain.discourse.group">Discourse</a> to discuss with SpeechBrain users coming from all around the world! <img src="img/logo_discourse.png"/></p>
-        		</div>
             <div class="main_title">
               <h2>Contributing to the code of SpeechBrain</h2>
               <p class="justified large"> The goal is to write a set of libraries that process audio and speech in several ways.

--- a/contributing.html
+++ b/contributing.html
@@ -109,7 +109,7 @@
               <p class="justified large"> Interractions between speech technologies and deep learning are various and numerous.
                 We believe that the toolkit will evolve accordingly to the needs
                 of the different research fields and industry. Examples of contributions include new recipes, better models for higher performance,
-                new external functionalities, or even core changes and extensions. Feel free to jump into our <a href="https://speechbrain.discourse.group">Discourse</a> or <a href="https://github.com/speechbrain/speechbrain">GitHub</a> to see if any existing issue remains unsolved!
+                new external functionalities, or even core changes and extensions. Feel free to jump into our <a href="https://github.com/speechbrain/speechbrain">GitHub</a> to see if any existing issue remains unsolved!
               </p>
               <h3>SpeechBrain Roadmap</h3>
               <p class="justified large"> As a community-based and open source project, SpeechBrain needs the help of its community to grow in the right direction. Opening the roadmap to our users enable the toolkit to benefit from new ideas, new research axes or even new technologies. The roadmap, available on our <a href="https://speechbrain.discourse.group/t/speechbrain-a-community-roadmap/179">Discourse</a>, lists all the changes and updates that need to be done in the current version of SpeechBrain. Users are more than welcome to propose new items via new Discourse topics!

--- a/index.html
+++ b/index.html
@@ -85,8 +85,8 @@
                 <p>A PyTorch Powered Speech Toolkit</p>
 								<a class="banner_btn" href="tutorial_basics.html">Get Started</a>
 								<a class="banner_btn2" href="https://github.com/speechbrain/speechbrain">GitHub</a>
-                <a class="banner_btn3" href="https://speechbrain.discourse.group">Discourse</a>
                 <a class="banner_btn4" href="https://huggingface.co/speechbrain"><img src="img/hf.svg" style="width:40px"/></a>
+				</br>
 		<iframe src="https://ghbtns.com/github-btn.html?user=speechbrain&repo=speechbrain&type=star&count=true&size=large&v=2" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
 
 								


### PR DESCRIPTION
Only one discourse link is left, the one that links to the roadmap. 

We will need to remove it when the roadmap will be available on the speechbrain GitHub repository. 
