### PR TITLE
Use img for discord invite widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 								<a class="banner_btn2" href="https://github.com/speechbrain/speechbrain">GitHub</a>
 								<a class="banner_btn4" href="https://huggingface.co/speechbrain"><img src="img/hf.svg" style="width:40px"/></a>
 								<iframe src="https://ghbtns.com/github-btn.html?user=speechbrain&repo=speechbrain&type=star&count=true&size=large&v=2" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
-								<iframe src="https://dcbadge.vercel.app/api/server/3wYvAaz3Ck?style=flat" frameborder="0" scrolling="0" width="170" height="30" title="Discord"></iframe>
+                                <a href="https://discord.gg/3wYvAaz3Ck"><img src="https://dcbadge.vercel.app/api/server/3wYvAaz3Ck?style=flat" /></a>
 		<br><br> <a href="https://drive.google.com/file/d/1Ig9KRzQ--H-0ugmz2UXA_pdxTuLBGhtk/view?usp=sharing""><font size="+1"> The call for Sponsors 2023 is open!</font></a>
 
 							</div>


### PR DESCRIPTION
The `<iframe>` is not supported outside of .md, according to the discord-md-badge docs. They provide an alternative for .html, in the README - https://github.com/ashmonty/discord-md-badge#html

This PR uses that strategy (`<img>` instead) to fix the Discord link on the page.