### PR TITLE
Fix banner icons

### DIFF
--- a/css/responsive.css
+++ b/css/responsive.css
@@ -277,9 +277,6 @@
 	.blog_banner .banner_inner .blog_b_text {
 		margin-top: 0px;
 	}
-	.home_banner_area .banner_inner .banner_content img{
-		display: none;
-	}
 	.home_banner_area .banner_inner .banner_content h5 {
 		margin-top: 0px;
 	}

--- a/css/style.css
+++ b/css/style.css
@@ -361,7 +361,7 @@ button:focus {
   .home_banner_area .banner_inner {
 
     width: 100%; }
-    .home_banner_area .banner_inner .home_left_img {
+    .home_banner_area .banner_inner {
       padding-top: 230px;
       padding-bottom: 230px; }
     .home_banner_area .banner_inner .col-lg-7 {

--- a/index.html
+++ b/index.html
@@ -101,6 +101,11 @@
                         </div>
 
                     </div>
+                    <div class="row" >
+                        <div class="col-lg-12" style="margin-top: 10px;" >
+                            <a href="https://drive.google.com/file/d/1Ig9KRzQ--H-0ugmz2UXA_pdxTuLBGhtk/view?usp=sharing"><font size="+1"> The call for Sponsors 2023 is open!</font></a>
+                        </div>
+                    </div>
 				</div>
 
       </div>

--- a/index.html
+++ b/index.html
@@ -86,18 +86,21 @@
 								<a class="banner_btn" href="tutorial_basics.html">Get Started</a>
 								<a class="banner_btn2" href="https://github.com/speechbrain/speechbrain">GitHub</a>
 								<a class="banner_btn4" href="https://huggingface.co/speechbrain"><img src="img/hf.svg" style="width:40px"/></a>
-								<iframe src="https://ghbtns.com/github-btn.html?user=speechbrain&repo=speechbrain&type=star&count=true&size=large&v=2" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
-                                <a href="https://discord.gg/3wYvAaz3Ck"><img src="https://dcbadge.vercel.app/api/server/3wYvAaz3Ck?style=flat" /></a>
-		<br><br> <a href="https://drive.google.com/file/d/1Ig9KRzQ--H-0ugmz2UXA_pdxTuLBGhtk/view?usp=sharing""><font size="+1"> The call for Sponsors 2023 is open!</font></a>
-
 							</div>
 						</div>
 						<div class="col-lg-5">
 							<div class="home_left_img">
-								<img class="img-fluid" src="img/speechbrain-round-logo.svg" style="max-height:300px"alt="">
+								<img class="img-fluid" style="margin-bottom: -20%; max-height:300px" src="img/speechbrain-round-logo.svg" alt="">
 							</div>
 						</div>
 					</div>
+                    <div class="row">
+                        <div class="col-lg-4" style="margin-top: 8px;">
+                            <iframe src="https://ghbtns.com/github-btn.html?user=speechbrain&repo=speechbrain&type=star&count=true&size=large&v=2" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
+                            <a href="https://discord.gg/3wYvAaz3Ck"><img style="margin-top: -30px; margin-left: -15px" src="https://dcbadge.vercel.app/api/server/3wYvAaz3Ck?style=flat" /></a>
+                        </div>
+
+                    </div>
 				</div>
 
       </div>


### PR DESCRIPTION
Objective: allow Discord, Hugging face and github icons to display in mobile vertical view.

- Move content onto a new row
- Remove display: none from responsive.css for banner content
- Modify margins

Wide screen desktop:
![image](https://user-images.githubusercontent.com/24813300/235181405-f33a9a36-d190-460e-b957-8c05b5ff613c.png)

500 px:
![image](https://user-images.githubusercontent.com/24813300/235181479-c21cf98f-96bb-4099-ba7b-2309fbb041c8.png)

400 px:
![image](https://user-images.githubusercontent.com/24813300/235181309-4a872ed6-1437-4c18-b042-49832f0ad053.png)

