### PR TITLE
Redirect tutorials to documentation

### DIFF
--- a/about.html
+++ b/about.html
@@ -20,45 +20,33 @@
     </head>
     <body>
 
-        <!--================Header Menu Area =================-->
-       <header class="header_area">
-            <div class="main_menu">
-            	<nav class="navbar navbar-expand-lg navbar-light">
-					<div class="container box_1620">
-						<!-- Brand and toggle get grouped for better mobile display -->
-						<a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
-						<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-						</button>
-						<!-- Collect the nav links, forms, and other content for toggling -->
-						<div class="collapse navbar-collapse offset" id="navbarSupportedContent">
-							<ul class="nav navbar-nav menu_nav justify-content-center">
-								<li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
-								<li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a>
-								<li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a>
-								<li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/en/latest/index.html">Documentation</a>
-								<li class="nav-item submenu dropdown">
-									<a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Tutorials</a>
-									<ul class="dropdown-menu">
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_basics.html">SpeechBrain Basics</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_advanced.html">SpeechBrain Advanced</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_asr.html">Speech Recognition</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_separation.html">Source Separation</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_enhancement.html">Speech Enhancement</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_classification.html">Speech Classification</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_processing.html">Speech Processing</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_nn.html">Neural Architectures</a></li>
-									</ul>
-								<li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a>
-								</li>
-							</ul>
-						</div>
-					</div>
-            	</nav>
-            </div>
-        </header>
+      <!--================Header Menu Area =================-->
+      <header class="header_area">
+          <div class="main_menu">
+              <nav class="navbar navbar-expand-lg navbar-light">
+                  <div class="container box_1620">
+                      <!-- Brand and toggle get grouped for better mobile display -->
+                      <a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
+                      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                          <span class="icon-bar"></span>
+                          <span class="icon-bar"></span>
+                          <span class="icon-bar"></span>
+                      </button>
+                      <!-- Collect the nav links, forms, and other content for toggling -->
+                      <div class="collapse navbar-collapse offset" id="navbarSupportedContent">
+                          <ul class="nav navbar-nav menu_nav justify-content-center">
+                              <li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
+                              <li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a></li>
+                              <li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a></li>
+                              <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Documentation</a></li>
+                              <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Tutorials</a></li>
+                              <li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a></li>
+                          </ul>
+                      </div>
+                  </div>
+              </nav>
+          </div>
+      </header>
         <!--================Header Menu Area =================-->
 
         <!--================Home Banner Area =================-->

--- a/contributing.html
+++ b/contributing.html
@@ -21,44 +21,32 @@
     <body>
 
         <!--================Header Menu Area =================-->
-        <header class="header_area">
-            <div class="main_menu">
-            	<nav class="navbar navbar-expand-lg navbar-light">
-					<div class="container box_1620">
-						<!-- Brand and toggle get grouped for better mobile display -->
-						<a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
-						<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-						</button>
-						<!-- Collect the nav links, forms, and other content for toggling -->
-						<div class="collapse navbar-collapse offset" id="navbarSupportedContent">
-							<ul class="nav navbar-nav menu_nav justify-content-center">
-								<li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
-								<li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a>
-								<li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a>
-								<li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/en/latest/index.html">Documentation</a>
-								<li class="nav-item submenu dropdown">
-									<a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Tutorials</a>
-									<ul class="dropdown-menu">
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_basics.html">SpeechBrain Basics</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_advanced.html">SpeechBrain Advanced</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_asr.html">Speech Recognition</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_separation.html">Source Separation</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_enhancement.html">Speech Enhancement</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_classification.html">Speech Classification</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_processing.html">Speech Processing</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_nn.html">Neural Architectures</a></li>
-									</ul>
-								<li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a>
-								</li>
-							</ul>
-						</div>
-					</div>
-            	</nav>
-            </div>
-        </header>
+      <header class="header_area">
+          <div class="main_menu">
+              <nav class="navbar navbar-expand-lg navbar-light">
+                  <div class="container box_1620">
+                      <!-- Brand and toggle get grouped for better mobile display -->
+                      <a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
+                      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                          <span class="icon-bar"></span>
+                          <span class="icon-bar"></span>
+                          <span class="icon-bar"></span>
+                      </button>
+                      <!-- Collect the nav links, forms, and other content for toggling -->
+                      <div class="collapse navbar-collapse offset" id="navbarSupportedContent">
+                          <ul class="nav navbar-nav menu_nav justify-content-center">
+                              <li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
+                              <li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a></li>
+                              <li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a></li>
+                              <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Documentation</a></li>
+                              <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Tutorials</a></li>
+                              <li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a></li>
+                          </ul>
+                      </div>
+                  </div>
+              </nav>
+          </div>
+      </header>
         <!--================Header Menu Area =================-->
 
         <!--================Home Banner Area =================-->

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
 							<div class="banner_content">
 								<h2>SpeechBrain <br /></h2>
                 <h3>Open-Source Conversational AI for Everyone</h3>
-								<a class="banner_btn" href="tutorial_basics.html">Get Started</a>
+								<a class="banner_btn" href="https://speechbrain.readthedocs.io/">Get Started</a>
 								<a class="banner_btn2" href="https://github.com/speechbrain/speechbrain">GitHub</a>
 								<a class="banner_btn4" href="https://huggingface.co/speechbrain"><img src="img/hf.svg" style="width:40px"/></a>
 								<a class="banner_btn4" href="https://www.youtube.com/@SpeechBrainProject/videos"><img src="img/youtube.svg" style="width:40px"/></a>
@@ -190,7 +190,7 @@
 									<div class="left_side_text">
 										<h3>Adapts to your needs.</h3>
 										<h6>You can install SpeechBrain via PyPI for quick access to its functionalities, or through a local install for accessing recipes and delving deeper into the toolkit.</h6>
-										<a class="main_btn" href="tutorial_basics.html">Get Started Now</a>
+										<a class="main_btn" href="https://speechbrain.readthedocs.io/">Get Started Now</a>
 									</div>
 								</div>
 								<div class="col-lg-6">
@@ -215,7 +215,7 @@
 									<div class="left_side_text">
 										<h3>A single command.</h3>
 										<h6>Each SpeechBrain recipe defines all hyperparameters into a single YAML file. The training process is then orchestrated by a Python script.</h6>
-										<a class="main_btn" href="tutorial_basics.html">Get Started Now</a>
+										<a class="main_btn" href="https://speechbrain.readthedocs.io/">Get Started Now</a>
 									</div>
 								</div>
 								<div class="col-lg-6">
@@ -243,7 +243,7 @@
   										<h6>
 										SpeechBrain is designed for research and development. Hence, flexibility, transparency, and replicability are core concepts to enhance our daily workflows. Users can easily define custom deep learning models, losses, training/evaluation loops, and input pipelines/transformations, and easily integrate into existing pipelines.
 										</h6>
-  										<a class="main_btn" href="tutorial_basics.html">Get Started Now</a>
+  										<a class="main_btn" href="https://speechbrain.readthedocs.io/">Get Started Now</a>
   									</div>
   								</div>
   								<div class="col-lg-6">

--- a/index.html
+++ b/index.html
@@ -37,40 +37,28 @@
         <!--================Header Menu Area =================-->
         <header class="header_area">
             <div class="main_menu">
-            	<nav class="navbar navbar-expand-lg navbar-light">
-					<div class="container box_1620">
-						<!-- Brand and toggle get grouped for better mobile display -->
-						<a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
-						<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-						</button>
-						<!-- Collect the nav links, forms, and other content for toggling -->
-						<div class="collapse navbar-collapse offset" id="navbarSupportedContent">
-							<ul class="nav navbar-nav menu_nav justify-content-center">
-								<li class="nav-item active"><a class="nav-link" href="">Home</a></li>
-								<li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a>
-								<li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a>
-								<li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/en/latest/index.html">Documentation</a>
-								<li class="nav-item submenu dropdown">
-									<a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Tutorials</a>
-									<ul class="dropdown-menu">
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_basics.html">SpeechBrain Basics</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_advanced.html">SpeechBrain Advanced</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_asr.html">Speech Recognition</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_separation.html">Source Separation</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_enhancement.html">Speech Enhancement</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_classification.html">Speech Classification</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_processing.html">Speech Processing</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_nn.html">Neural Architectures</a></li>
-									</ul>
-								<li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a>
-								</li>
-							</ul>
-						</div>
-					</div>
-            	</nav>
+                <nav class="navbar navbar-expand-lg navbar-light">
+                    <div class="container box_1620">
+                        <!-- Brand and toggle get grouped for better mobile display -->
+                        <a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
+                        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                        </button>
+                        <!-- Collect the nav links, forms, and other content for toggling -->
+                        <div class="collapse navbar-collapse offset" id="navbarSupportedContent">
+                            <ul class="nav navbar-nav menu_nav justify-content-center">
+                                <li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
+                                <li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a></li>
+                                <li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Documentation</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Tutorials</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </nav>
             </div>
         </header>
         <!--================Header Menu Area =================-->

--- a/sb_summit2023.html
+++ b/sb_summit2023.html
@@ -23,40 +23,28 @@
         <!--================Header Menu Area =================-->
         <header class="header_area">
             <div class="main_menu">
-            	<nav class="navbar navbar-expand-lg navbar-light">
-					<div class="container box_1620">
-						<!-- Brand and toggle get grouped for better mobile display -->
-						<a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
-						<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-						</button>
-						<!-- Collect the nav links, forms, and other content for toggling -->
-						<div class="collapse navbar-collapse offset" id="navbarSupportedContent">
-							<ul class="nav navbar-nav menu_nav justify-content-center">
-                                <li class="nav-item active"><a class="nav-link" href="sb_summit2023.html">Online SpeechBrain Summit</a></li>
-								<li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
-								<li class="nav-item"><a class="nav-link" href="#">About SpeechBrain</a>
-                  <li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a>
-                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/en/latest/index.html">Documentation</a>
-								<li class="nav-item submenu dropdown">
-									<a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Tutorials</a>
-                  <ul class="dropdown-menu">
-                    <li class="nav-item"><a class="nav-link" href="tutorial_basics.html">SpeechBrain Basics</a></li>
-                    <li class="nav-item"><a class="nav-link" href="tutorial_advanced.html">SpeechBrain Advanced</a></li>
-                    <li class="nav-item"><a class="nav-link" href="tutorial_asr.html">Speech Recognition</a></li>
-                    <li class="nav-item"><a class="nav-link" href="tutorial_separation.html">Source Separation</a></li>
-                    <li class="nav-item"><a class="nav-link" href="tutorial_enhancement.html">Speech Enhancement</a></li>
-		                <li class="nav-item"><a class="nav-link" href="tutorial_classification.html">Speech Classification</a></li>
-                    <li class="nav-item"><a class="nav-link" href="tutorial_processing.html">Speech Processing</a></li>
-		                <li class="nav-item"><a class="nav-link" href="tutorial_nn.html">Neural Architectures</a></li>
-									</ul>
-								</li>
-							</ul>
-						</div>
-					</div>
-            	</nav>
+                <nav class="navbar navbar-expand-lg navbar-light">
+                    <div class="container box_1620">
+                        <!-- Brand and toggle get grouped for better mobile display -->
+                        <a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
+                        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                        </button>
+                        <!-- Collect the nav links, forms, and other content for toggling -->
+                        <div class="collapse navbar-collapse offset" id="navbarSupportedContent">
+                            <ul class="nav navbar-nav menu_nav justify-content-center">
+                                <li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
+                                <li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a></li>
+                                <li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Documentation</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Tutorials</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </nav>
             </div>
         </header>
         <!--================Header Menu Area =================-->

--- a/tutorial_advanced.html
+++ b/tutorial_advanced.html
@@ -5,7 +5,11 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <link rel="icon" href="img/favicon.ico">
-        <title>SpeechBrain Advanced</title>
+        
+        <script type="text/javascript">
+            window.location.href = "https://speechbrain.readthedocs.io/";
+        </script>
+        <title>SpeechBrain Tutorials</title>
         <!-- Bootstrap CSS -->
         <link rel="stylesheet" href="css/bootstrap.css">
         <link rel="stylesheet" href="vendors/linericon/style.css">
@@ -23,40 +27,28 @@
         <!--================Header Menu Area =================-->
         <header class="header_area">
             <div class="main_menu">
-            	<nav class="navbar navbar-expand-lg navbar-light">
-					<div class="container box_1620">
-						<!-- Brand and toggle get grouped for better mobile display -->
-						<a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
-						<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-						</button>
-						<!-- Collect the nav links, forms, and other content for toggling -->
-						<div class="collapse navbar-collapse offset" id="navbarSupportedContent">
-							<ul class="nav navbar-nav menu_nav justify-content-center">
-								<li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
-								<li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a>
-								<li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a>
-								<li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/en/latest/index.html">Documentation</a>
-								<li class="nav-item submenu dropdown">
-									<a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Tutorials</a>
-									<ul class="dropdown-menu">
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_basics.html">SpeechBrain Basics</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_advanced.html">SpeechBrain Advanced</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_asr.html">Speech Recognition</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_separation.html">Source Separation</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_enhancement.html">Speech Enhancement</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_classification.html">Speech Classification</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_processing.html">Speech Processing</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_nn.html">Neural Architectures</a></li>
-									</ul>
-								<li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a>
-								</li>
-							</ul>
-						</div>
-					</div>
-            	</nav>
+                <nav class="navbar navbar-expand-lg navbar-light">
+                    <div class="container box_1620">
+                        <!-- Brand and toggle get grouped for better mobile display -->
+                        <a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
+                        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                        </button>
+                        <!-- Collect the nav links, forms, and other content for toggling -->
+                        <div class="collapse navbar-collapse offset" id="navbarSupportedContent">
+                            <ul class="nav navbar-nav menu_nav justify-content-center">
+                                <li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
+                                <li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a></li>
+                                <li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Documentation</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Tutorials</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </nav>
             </div>
         </header>
         <!--================Header Menu Area =================-->
@@ -64,327 +56,71 @@
         <!--================Home Banner Area =================-->
         <section class="home_banner_area blog_banner">
             <div class="banner_inner d-flex align-items-center">
-            	<div class="overlay bg-parallax" data-stellar-ratio="0.9" data-stellar-vertical-offset="0" data-background=""></div>
-				<div class="container">
-					<div class="blog_b_text text-center">
-						<h2>SpeechBrain Tutorials</h2>
-						<h3>SpeechBrain Advanced</h3>
+                <div class="overlay bg-parallax" data-stellar-ratio="0.9" data-stellar-vertical-offset="0" data-background=""></div>
+                <div class="container">
+                    <div class="blog_b_text text-center">
+                        <h2>Tutorials have moved</h2>
+                        <h3><br>Click <a style="color: white; font-weight: bold; text-decoration: underline;" href="https://speechbrain.readthedocs.io/">here</a> if you are not being redirected.</h3>
 
-					</div>
-				</div>
+                    </div>
+                </div>
             </div>
         </section>
         <!--================End Home Banner Area =================-->
-	<div class="alert alert-primary" role="alert" style="text-align: center; font-size: 24px;">
-	    🎉 SpeechBrain 1.0 is out.  <a href="https://colab.research.google.com/drive/1IEPfKRuvJRSjoxu22GZhb3czfVHsAy0s?usp=sharing"><strong> Check out what's new!</strong></a>
-	</div>
+    <div class="alert alert-primary" role="alert" style="text-align: center; font-size: 24px;">
+        🎉 SpeechBrain 1.0 is out.  <a href="https://colab.research.google.com/drive/1IEPfKRuvJRSjoxu22GZhb3czfVHsAy0s?usp=sharing"><strong> Check out what's new!</strong></a>
+    </div>
         <!--================Blog Categorie Area =================-->
         <section class="blog_categorie_area">
-          <!-- We don't have category for now -->
+            <!-- We don't have category for now -->
         </section>
         <!--================Blog Categorie Area =================-->
 
         <!--================Blog Area =================-->
         <section class="blog_area">
             <div class="container">
-                <div class="row">
-                    <div class="col-md-9">
-                        <div class="blog_left_sidebar">
-			 <article class="row blog_item">
-                             <div class="col-md-3">
-                                 <div class="blog_info text-right">
-                                      <div class="post_tag">
-                                          <a class="active" href="#">SpeechBrain Advanced</a>
-                                      </div>
-                                      <ul class="blog_meta list">
-                                          <li><a href="about.html">Nautsch  A.<i class="lnr lnr-user"></i></a></li>
-                                          <li><a href="#">June. 2022<i class="lnr lnr-calendar-full"></i></a></li>
-                                          <li><a href="#">Difficulty: medium<i class="lnr lnr-cog"></i></a></li>
-                                          <li><a href="#">Time: 45min<i class="lnr lnr-hourglass"></i></a></li>
-                                      </ul>
-                                  </div>
-                             </div>
-                              <div class="col-md-9">
-                                <div class="blog_post">
-                                    <div class="blog_details">
-                                        <h2>Profiling and Benchmark</h2>
-                                        <p>Profiling and benchmark of SpeechBrain models can serve different purposes and look at different angles. Performance requirements are highly particular to the use case with that one desires to use SpeechBrain. This provides means to comprehensive self-learning as a starting point to individual growth beyond the provided.</p>
-                                        <a href="https://colab.research.google.com/drive/1X9eeAEy19BgEJX4YZWjo1Huku_8cOUGJ?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                    </div>
-                                </div>
-                              </div>
-                          </article>
-                          <article class="row blog_item">
-                             <div class="col-md-3">
-                                 <div class="blog_info text-right">
-                                      <div class="post_tag">
-                                          <a class="active" href="#">SpeechBrain Advanced</a>
-                                      </div>
-                                      <ul class="blog_meta list">
-                                          <li><a href="about.html">Nautsch  A. and Cornell S.<i class="lnr lnr-user"></i></a></li>
-                                          <li><a href="#">Nov. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                          <li><a href="#">Difficulty: medium<i class="lnr lnr-cog"></i></a></li>
-                                          <li><a href="#">Time: 25min<i class="lnr lnr-hourglass"></i></a></li>
-                                      </ul>
-                                  </div>
-                             </div>
-                              <div class="col-md-9">
-                                <div class="blog_post">
-                                    <div class="blog_details">
-                                        <h2>Dynamic Batching</h2>
-                                        <p>Do you want to speed up training or make it less memory-demanding? One possible solution could be dynamic batching. With this approach, you can dynamically sample batches composed of a variable number of sentences. In this tutorial, we show how to use this technique within SpeechBrain.</p>
-                                        <a href="https://colab.research.google.com/drive/1mypqbHDrusZaIbqPoiEGY-WIbnpMHa2I?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                    </div>
-                                </div>
-                              </div>
-                          </article>
-                          <article class="row blog_item">
-                             <div class="col-md-3">
-                                 <div class="blog_info text-right">
-                                      <div class="post_tag">
-                                          <a class="active" href="#">SpeechBrain Advanced</a>
-                                      </div>
-                                      <ul class="blog_meta list">
-                                          <li><a href="about.html">Ploujnikov A.<i class="lnr lnr-user"></i></a></li>
-                                          <li><a href="#">Dec. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                          <li><a href="#">Difficulty: medium<i class="lnr lnr-cog"></i></a></li>
-                                          <li><a href="#">Time: 25min<i class="lnr lnr-hourglass"></i></a></li>
-                                      </ul>
-                                  </div>
-                             </div>
-                              <div class="col-md-9">
-                                <div class="blog_post">
-                                    <div class="blog_details">
-                                        <h2>Hyperparameter Optimization</h2>
-                                        <p>Do you want to optimize the hyperparameters of your model? Are you tired of doing it by hand? This tutorial will describe how you can optimize the hyperparameter of your SpeechBrain model using the Orion toolkit.</p>
-                                        <a href="https://colab.research.google.com/drive/1b-5EOjZC7M9RvfWZ0Pq0HMV0KmQKu730?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                    </div>
-                                </div>
-                              </div>
-                          </article>
-                          <article class="row blog_item">
-                             <div class="col-md-3">
-                                 <div class="blog_info text-right">
-                                      <div class="post_tag">
-                                          <a class="active" href="#">SpeechBrain Advanced</a>
-                                      </div>
-                                      <ul class="blog_meta list">
-                                          <li><a href="about.html">Gao Y. & Parcollet T.<i class="lnr lnr-user"></i></a></li>
-                                          <li><a href="#">Nov. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                          <li><a href="#">Difficulty: high<i class="lnr lnr-cog"></i></a></li>
-                                          <li><a href="#">Time: 45min<i class="lnr lnr-hourglass"></i></a></li>
-                                      </ul>
-                                  </div>
-                             </div>
-                              <div class="col-md-9">
-                                <div class="blog_post">
-                                    <div class="blog_details">
-                                        <h2>Federated Speech Model Training via SpeechBrain and Flower</h2>
-                                        <p>Are you interested in both federated learning (FL) and speech, but worried about the proper tools to run experiments? Today you will get the answer.
-                                          This tutorial introduces how to integrate Flower and SpeechBrain to achieve federated speech model training.</p>
-                                        <a href="https://colab.research.google.com/drive/1Jmx6NhYuLy0Rj3wtF3l3PIxLFSwI0Cym?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                    </div>
-                                </div>
-                              </div>
-                          </article>
-                          <article class="row blog_item">
-                             <div class="col-md-3">
-                                 <div class="blog_info text-right">
-                                      <div class="post_tag">
-                                          <a class="active" href="#">SpeechBrain Advanced</a>
-                                      </div>
-                                      <ul class="blog_meta list">
-                                          <li><a href="about.html">Parcollet T.<i class="lnr lnr-user"></i></a></li>
-                                          <li><a href="#">Sept.. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                          <li><a href="#">Difficulty: medium<i class="lnr lnr-cog"></i></a></li>
-                                          <li><a href="#">Time: 30min<i class="lnr lnr-hourglass"></i></a></li>
-                                      </ul>
-                                  </div>
-                             </div>
-                              <div class="col-md-9">
-                                <div class="blog_post">
-                                    <div class="blog_details">
-                                        <h2>Inferring on your own SpeechBrain models</h2>
-                                        <p>In this tutorial, we will learn the three different ways of inferring on a trained model.
-                                          This is particularly useful to debug your pipeline or to deploy a model in a production context.</p>
-                                        <a href="https://colab.research.google.com/drive/1137MD-gAERblRAVhxDnwNXV3YyAiwtxV?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                    </div>
-                                </div>
-                              </div>
-                          </article>
-                          <article class="row blog_item">
-                             <div class="col-md-3">
-                                 <div class="blog_info text-right">
-                                      <div class="post_tag">
-                                          <a class="active" href="#">SpeechBrain Advanced</a>
-                                      </div>
-                                      <ul class="blog_meta list">
-                                          <li><a href="about.html">Cornell S. & Parcollet T.<i class="lnr lnr-user"></i></a></li>
-                                          <li><a href="#">Mar. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                          <li><a href="#">Difficulty: medium<i class="lnr lnr-cog"></i></a></li>
-                                          <li><a href="#">Time: 30min<i class="lnr lnr-hourglass"></i></a></li>
-                                      </ul>
-                                  </div>
-                             </div>
-                              <div class="col-md-9">
-                                <div class="blog_post">
-                                    <div class="blog_details">
-                                        <h2>Pre-trained Models and Fine-Tuning with <img src="img/hf.ico" alt="drawing" width="40" style="box-shadow: 0px 0px 0px -0px rgb(255, 255, 255)"/></h2>
-                                        <p>Training DNN models is often very time-consuming and expensive.
-                                          For this reason, whenever it is possible, using off-the-shelf pretrained
-                                          models can be convenient in various scenarios.
-                                          We provide a simple and straightforward way to download and instantiate a
-                                          state-of-the-art pretrained-model from <img src="img/hf.ico" alt="drawing" width="20"/> HuggingFace <img src="img/hf.ico" alt="drawing" width="20"/> and use it either for direct inference or
-                                          or fine-tuning/knowledge distillation or whatever new fancy technique you can come up with!</p>
-                                        <a href="https://colab.research.google.com/drive/1PK3S1_hgKH0H7Eio1HUxa6XLykUfAlnV?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                    </div>
-                                </div>
-                              </div>
-                          </article>
-                          <article class="row blog_item">
-                             <div class="col-md-3">
-                                 <div class="blog_info text-right">
-                                      <div class="post_tag">
-                                          <a class="active" href="#">SpeechBrain Advanced</a>
-                                      </div>
-                                      <ul class="blog_meta list">
-                                        <li><a href="about.html">Rouhe A.<i class="lnr lnr-user"></i></a></li>
-                                        <li><a href="#">Feb. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                        <li><a href="#">Difficulty: medium<i class="lnr lnr-cog"></i></a></li>
-                                        <li><a href="#">Time: 15min<i class="lnr lnr-hourglass"></i></a></li>
-                                      </ul>
-                                  </div>
-                             </div>
-                              <div class="col-md-9">
-                                <div class="blog_post">
-                                    <div class="blog_details">
-                                        <h2>Data Loading for Big Datasets and Shared Filesystems</h2>
-                                        <p>Do you have a huge dataset stored in a shared file system? This tutorial will show you how to load large datasets from the shared file system and use them for training a neural network with SpeechBrain.
-					In particular, we describe a solution based on the WebDataset library, that is easy to integrate within the SpeechBrain toolkit. </p>
-                                        <a href="https://colab.research.google.com/drive/1s171JSA53_ktvc1zQp6uMcM0TChtCcZ9?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                    </div>
-                                </div>
-                              </div>
-                          </article>
-                          <article class="row blog_item">
-                             <div class="col-md-3">
-                                 <div class="blog_info text-right">
-                                      <div class="post_tag">
-                                          <a class="active" href="#">SpeechBrain Advanced</a>
-                                      </div>
-                                      <ul class="blog_meta list">
-                                          <li><a href="about.html">Heba A. & Parcollet T.<i class="lnr lnr-user"></i></a></li>
-                                          <li><a href="#">Feb. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                          <li><a href="#">Difficulty: easy<i class="lnr lnr-cog"></i></a></li>
-                                          <li><a href="#">Time: 20min<i class="lnr lnr-hourglass"></i></a></li>
-                                      </ul>
-                                  </div>
-                             </div>
-                              <div class="col-md-9">
-                                <div class="blog_post">
-                                    <div class="blog_details">
-                                        <h2>Text Tokenizer</h2>
-                                        <p>Machine Learning tasks that process text may contain thousands of vocabulary
-                                          words which leads to models dealing with huge embeddings as input/output
-                                          (e.g. for one-hot-vectors and ndim=vocabulary_size). This causes an important consumption of memory,
-                                          complexe computations, and more importantly, sub-optimal learning due to extremely sparse and cumbersome
-                                          one-hot vectors. In this tutorial, we provide all the basics needed to correctly use the SpeechBrain Tokenizer relying
-                                          on SentencePiece (BPE and unigram).</p>
-                                        <a href="https://colab.research.google.com/drive/12yE3myHSH-eUxzNM0-FLtEOhzdQoLYWe?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                    </div>
-                                </div>
-                              </div>
-                          </article>
-
-                          <article class="row blog_item">
-                             <div class="col-md-3">
-                                 <div class="blog_info text-right">
-                                      <div class="post_tag">
-                                          <a class="active" href="#">SpeechBrain Advanced</a>
-                                      </div>
-                                      <ul class="blog_meta list">
-                                          <li><a href="about.html">Lam J.<i class="lnr lnr-user"></i></a></li>
-                                          <li><a href="#">Apr. 2024<i class="lnr lnr-calendar-full"></i></a></li>
-                                          <li><a href="#">Difficulty: medium<i class="lnr lnr-cog"></i></a></li>
-                                          <li><a href="#">Time: 30min<i class="lnr lnr-hourglass"></i></a></li>
-                                      </ul>
-                                  </div>
-                             </div>
-                              <div class="col-md-9">
-                                <div class="blog_post">
-                                    <div class="blog_details">
-                                        <h2>Model Quantization</h2>
-                                        <p>Quantization is a necessary step for many deep neural networks, particularly for tasks requiring low latency and efficient memory usage like real-time automatic speech recognition. This tutorial will introduce the problem of quantization and explain how to perform quantization using SpeechBrain.</p>
-                                        <a href="https://colab.research.google.com/drive/1IoxCu_hJ6T9655a-77vWyvwOjZHboFFG?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                    </div>
-                                </div>
-                              </div>
-                          </article>
-				
-                            <nav class="blog-pagination justify-content-center d-flex">
-		                        <ul class="pagination">
-		                            <li class="page-item">
-		                                <a href="#" class="page-link" aria-label="Previous">
-		                                    <span aria-hidden="true">
-		                                        <span class="lnr lnr-chevron-left"></span>
-		                                    </span>
-		                                </a>
-		                            </li>
-		                            <li class="page-item active"><a href="#" class="page-link">1</a></li>
-		                            <li class="page-item">
-		                                <a href="#" class="page-link" aria-label="Next">
-		                                    <span aria-hidden="true">
-		                                        <span class="lnr lnr-chevron-right"></span>
-		                                    </span>
-		                                </a>
-		                            </li>
-		                        </ul>
-		                    </nav>
-                        </div>
-                    </div>
-                </div>
             </div>
         </section>
         <!--================Blog Area =================-->
 
         <!--================Footer Area =================-->
         <footer class="footer_area p_120">
-        	<div class="container">
-        		<div class="row footer_inner">
-        			<div class="col-lg-5 col-sm-6">
-        				<aside class="f_widget ab_widget">
-        					<div class="f_title">
-        						<h3>About Us</h3>
-        					</div>
-        					<p style="text-align:justify">SpeechBrain isn't a company or an association.
+            <div class="container">
+                <div class="row footer_inner">
+                    <div class="col-lg-5 col-sm-6">
+                        <aside class="f_widget ab_widget">
+                            <div class="f_title">
+                                <h3>About Us</h3>
+                            </div>
+                            <p style="text-align:justify">SpeechBrain isn't a company or an association.
                     It is an open-source toolkit and a community created by Dr. Mirco Ravanelli and co-created by Dr. Titouan Parcollet.
                     We aim at making speech technologies more accessible for the community. </p>
-        					<p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
+                            <p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
 Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved</p>
-        				</aside>
-        			</div>
-        			<div class="col-lg-5 col-sm-6">
-        				<aside class="f_widget news_widget">
-        					<div class="f_title">
-        						<h3>Opportunities</h3>
-        					</div>
-        					<p>Thanks to our sponsors, we often recruit talented candidates to continue expanding the functionalities of SpeechBrain.
+                        </aside>
+                    </div>
+                    <div class="col-lg-5 col-sm-6">
+                        <aside class="f_widget news_widget">
+                            <div class="f_title">
+                                <h3>Opportunities</h3>
+                            </div>
+                            <p>Thanks to our sponsors, we often recruit talented candidates to continue expanding the functionalities of SpeechBrain.
                     Feel free to contact us at: speechbrainproject@gmail.com</p>
-        				</aside>
-        			</div>
-        			<div class="col-lg-2">
-        				<aside class="f_widget social_widget">
-        					<div class="f_title">
-        						<h3>Follow Us</h3>
-        					</div>
-        					<p>Let us be social</p>
-        					<ul class="list">
-        						<li><a href="https://twitter.com/SpeechBrain1"><i class="fa fa-twitter"></i></a></li>
-        					</ul>
-        				</aside>
-        			</div>
-        		</div>
-        	</div>
+                        </aside>
+                    </div>
+                    <div class="col-lg-2">
+                        <aside class="f_widget social_widget">
+                            <div class="f_title">
+                                <h3>Follow Us</h3>
+                            </div>
+                            <p>Let us be social</p>
+                            <ul class="list">
+                                <li><a href="https://twitter.com/SpeechBrain1"><i class="fa fa-twitter"></i></a></li>
+                            </ul>
+                        </aside>
+                    </div>
+                </div>
+            </div>
         </footer>
         <!--================End Footer Area =================-->
 

--- a/tutorial_asr.html
+++ b/tutorial_asr.html
@@ -4,11 +4,12 @@
         <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <!-- BLOCK INDEX -->
-        <meta name="robots" content="noindex">
-        <!-- BLOCK INDEX -->
         <link rel="icon" href="img/favicon.ico">
-        <title>SpeechBrain</title>
+        
+        <script type="text/javascript">
+            window.location.href = "https://speechbrain.readthedocs.io/";
+        </script>
+        <title>SpeechBrain Tutorials</title>
         <!-- Bootstrap CSS -->
         <link rel="stylesheet" href="css/bootstrap.css">
         <link rel="stylesheet" href="vendors/linericon/style.css">
@@ -26,40 +27,28 @@
         <!--================Header Menu Area =================-->
         <header class="header_area">
             <div class="main_menu">
-            	<nav class="navbar navbar-expand-lg navbar-light">
-					<div class="container box_1620">
-						<!-- Brand and toggle get grouped for better mobile display -->
-						<a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
-						<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-						</button>
-						<!-- Collect the nav links, forms, and other content for toggling -->
-						<div class="collapse navbar-collapse offset" id="navbarSupportedContent">
-							<ul class="nav navbar-nav menu_nav justify-content-center">
-								<li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
-								<li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a>
-								<li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a>
-								<li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/en/latest/index.html">Documentation</a>
-								<li class="nav-item submenu dropdown">
-									<a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Tutorials</a>
-									<ul class="dropdown-menu">
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_basics.html">SpeechBrain Basics</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_advanced.html">SpeechBrain Advanced</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_asr.html">Speech Recognition</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_separation.html">Source Separation</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_enhancement.html">Speech Enhancement</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_classification.html">Speech Classification</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_processing.html">Speech Processing</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_nn.html">Neural Architectures</a></li>
-									</ul>
-								<li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a>
-								</li>
-							</ul>
-						</div>
-					</div>
-            	</nav>
+                <nav class="navbar navbar-expand-lg navbar-light">
+                    <div class="container box_1620">
+                        <!-- Brand and toggle get grouped for better mobile display -->
+                        <a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
+                        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                        </button>
+                        <!-- Collect the nav links, forms, and other content for toggling -->
+                        <div class="collapse navbar-collapse offset" id="navbarSupportedContent">
+                            <ul class="nav navbar-nav menu_nav justify-content-center">
+                                <li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
+                                <li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a></li>
+                                <li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Documentation</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Tutorials</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </nav>
             </div>
         </header>
         <!--================Header Menu Area =================-->
@@ -67,120 +56,71 @@
         <!--================Home Banner Area =================-->
         <section class="home_banner_area blog_banner">
             <div class="banner_inner d-flex align-items-center">
-            	<div class="overlay bg-parallax" data-stellar-ratio="0.9" data-stellar-vertical-offset="0" data-background=""></div>
-				<div class="container">
-					<div class="blog_b_text text-center">
-						<h2>SpeechBrain Tutorials</h2>
-						<h3>Speech Recognition</h3>
+                <div class="overlay bg-parallax" data-stellar-ratio="0.9" data-stellar-vertical-offset="0" data-background=""></div>
+                <div class="container">
+                    <div class="blog_b_text text-center">
+                        <h2>Tutorials have moved</h2>
+                        <h3><br>Click <a style="color: white; font-weight: bold; text-decoration: underline;" href="https://speechbrain.readthedocs.io/">here</a> if you are not being redirected.</h3>
 
-					</div>
-				</div>
+                    </div>
+                </div>
             </div>
         </section>
         <!--================End Home Banner Area =================-->
-	<div class="alert alert-primary" role="alert" style="text-align: center; font-size: 24px;">
-	    🎉 SpeechBrain 1.0 is out.  <a href="https://colab.research.google.com/drive/1IEPfKRuvJRSjoxu22GZhb3czfVHsAy0s?usp=sharing"><strong> Check out what's new!</strong></a>
-	</div>
+    <div class="alert alert-primary" role="alert" style="text-align: center; font-size: 24px;">
+        🎉 SpeechBrain 1.0 is out.  <a href="https://colab.research.google.com/drive/1IEPfKRuvJRSjoxu22GZhb3czfVHsAy0s?usp=sharing"><strong> Check out what's new!</strong></a>
+    </div>
         <!--================Blog Categorie Area =================-->
         <section class="blog_categorie_area">
-          <!-- We don't have category for now -->
+            <!-- We don't have category for now -->
         </section>
         <!--================Blog Categorie Area =================-->
 
         <!--================Blog Area =================-->
         <section class="blog_area">
             <div class="container">
-                <div class="row">
-                    <div class="col-md-9">
-                        <div class="blog_left_sidebar">
-                          <article class="row blog_item">
-                             <div class="col-md-3">
-                                 <div class="blog_info text-right">
-                                      <div class="post_tag">
-                                          <a class="active" href="#">Speech Recognition</a>
-                                      </div>
-                                      <ul class="blog_meta list">
-                                          <li><a href="about.html">Ravanelli M. & Parcollet T.<i class="lnr lnr-user"></i></a></li>
-                                          <li><a href="#">Apr. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                          <li><a href="#">Difficulty: medium<i class="lnr lnr-cog"></i></a></li>
-                                          <li><a href="#">Time: 45min<i class="lnr lnr-hourglass"></i></a></li>
-                                      </ul>
-                                  </div>
-                             </div>
-                              <div class="col-md-9">
-                                <div class="blog_post">
-                                    <div class="blog_details">
-                                        <h2>Speech Recognition From Scratch</h2>
-                                        <p>Do you want to figure out how to implement your speech recognizer with SpeechBrain? Look no further, you're in the right place. This tutorial will walk you through all the steps needed to implement an offline end-to-end attention-based speech recognizer. This is a self-contained tutorial that will help you "connecting the dots" across all the steps needed to train a modern speech recognizer. We will address data preparation, tokenizer training, language model, ASR model, and inference. We will explain how to train your model on your data.</p>
-                                        <a href="https://colab.research.google.com/drive/1aFgzrUv3udM_gNJNUoLaHIm78QHtxdIz?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                    </div>
-                                </div>
-                              </div>
-                          </article>
-                            <nav class="blog-pagination justify-content-center d-flex">
-		                        <ul class="pagination">
-		                            <li class="page-item">
-		                                <a href="#" class="page-link" aria-label="Previous">
-		                                    <span aria-hidden="true">
-		                                        <span class="lnr lnr-chevron-left"></span>
-		                                    </span>
-		                                </a>
-		                            </li>
-		                            <li class="page-item active"><a href="#" class="page-link">1</a></li>
-		                            <li class="page-item">
-		                                <a href="#" class="page-link" aria-label="Next">
-		                                    <span aria-hidden="true">
-		                                        <span class="lnr lnr-chevron-right"></span>
-		                                    </span>
-		                                </a>
-		                            </li>
-		                        </ul>
-		                    </nav>
-                        </div>
-                    </div>
-                </div>
             </div>
         </section>
         <!--================Blog Area =================-->
 
         <!--================Footer Area =================-->
         <footer class="footer_area p_120">
-        	<div class="container">
-        		<div class="row footer_inner">
-        			<div class="col-lg-5 col-sm-6">
-        				<aside class="f_widget ab_widget">
-        					<div class="f_title">
-        						<h3>About Us</h3>
-        					</div>
-        					<p style="text-align:justify">SpeechBrain isn't a company or an association.
+            <div class="container">
+                <div class="row footer_inner">
+                    <div class="col-lg-5 col-sm-6">
+                        <aside class="f_widget ab_widget">
+                            <div class="f_title">
+                                <h3>About Us</h3>
+                            </div>
+                            <p style="text-align:justify">SpeechBrain isn't a company or an association.
                     It is an open-source toolkit and a community created by Dr. Mirco Ravanelli and co-created by Dr. Titouan Parcollet.
                     We aim at making speech technologies more accessible for the community. </p>
-        					<p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
+                            <p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
 Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved</p>
-        				</aside>
-        			</div>
-        			<div class="col-lg-5 col-sm-6">
-        				<aside class="f_widget news_widget">
-        					<div class="f_title">
-        						<h3>Opportunities</h3>
-        					</div>
-        					<p>Thanks to our sponsors, we often recruit talented candidates to continue expanding the functionalities of SpeechBrain.
+                        </aside>
+                    </div>
+                    <div class="col-lg-5 col-sm-6">
+                        <aside class="f_widget news_widget">
+                            <div class="f_title">
+                                <h3>Opportunities</h3>
+                            </div>
+                            <p>Thanks to our sponsors, we often recruit talented candidates to continue expanding the functionalities of SpeechBrain.
                     Feel free to contact us at: speechbrainproject@gmail.com</p>
-        				</aside>
-        			</div>
-        			<div class="col-lg-2">
-        				<aside class="f_widget social_widget">
-        					<div class="f_title">
-        						<h3>Follow Us</h3>
-        					</div>
-        					<p>Let us be social</p>
-        					<ul class="list">
-        						<li><a href="https://twitter.com/SpeechBrain1"><i class="fa fa-twitter"></i></a></li>
-        					</ul>
-        				</aside>
-        			</div>
-        		</div>
-        	</div>
+                        </aside>
+                    </div>
+                    <div class="col-lg-2">
+                        <aside class="f_widget social_widget">
+                            <div class="f_title">
+                                <h3>Follow Us</h3>
+                            </div>
+                            <p>Let us be social</p>
+                            <ul class="list">
+                                <li><a href="https://twitter.com/SpeechBrain1"><i class="fa fa-twitter"></i></a></li>
+                            </ul>
+                        </aside>
+                    </div>
+                </div>
+            </div>
         </footer>
         <!--================End Footer Area =================-->
 

--- a/tutorial_basics.html
+++ b/tutorial_basics.html
@@ -5,7 +5,11 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <link rel="icon" href="img/favicon.ico">
-        <title>SpeechBrain Basics</title>
+        
+        <script type="text/javascript">
+            window.location.href = "https://speechbrain.readthedocs.io/";
+        </script>
+        <title>SpeechBrain Tutorials</title>
         <!-- Bootstrap CSS -->
         <link rel="stylesheet" href="css/bootstrap.css">
         <link rel="stylesheet" href="vendors/linericon/style.css">
@@ -23,40 +27,28 @@
         <!--================Header Menu Area =================-->
         <header class="header_area">
             <div class="main_menu">
-            	<nav class="navbar navbar-expand-lg navbar-light">
-					<div class="container box_1620">
-						<!-- Brand and toggle get grouped for better mobile display -->
-						<a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
-						<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-						</button>
-						<!-- Collect the nav links, forms, and other content for toggling -->
-						<div class="collapse navbar-collapse offset" id="navbarSupportedContent">
-							<ul class="nav navbar-nav menu_nav justify-content-center">
-								<li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
-								<li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a>
-								<li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a>
-								<li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/en/latest/index.html">Documentation</a>
-								<li class="nav-item submenu dropdown">
-									<a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Tutorials</a>
-									<ul class="dropdown-menu">
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_basics.html">SpeechBrain Basics</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_advanced.html">SpeechBrain Advanced</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_asr.html">Speech Recognition</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_separation.html">Source Separation</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_enhancement.html">Speech Enhancement</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_classification.html">Speech Classification</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_processing.html">Speech Processing</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_nn.html">Neural Architectures</a></li>
-									</ul>
-								<li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a>
-								</li>
-							</ul>
-						</div>
-					</div>
-            	</nav>
+                <nav class="navbar navbar-expand-lg navbar-light">
+                    <div class="container box_1620">
+                        <!-- Brand and toggle get grouped for better mobile display -->
+                        <a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
+                        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                        </button>
+                        <!-- Collect the nav links, forms, and other content for toggling -->
+                        <div class="collapse navbar-collapse offset" id="navbarSupportedContent">
+                            <ul class="nav navbar-nav menu_nav justify-content-center">
+                                <li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
+                                <li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a></li>
+                                <li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Documentation</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Tutorials</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </nav>
             </div>
         </header>
         <!--================Header Menu Area =================-->
@@ -64,284 +56,71 @@
         <!--================Home Banner Area =================-->
         <section class="home_banner_area blog_banner">
             <div class="banner_inner d-flex align-items-center">
-            	<div class="overlay bg-parallax" data-stellar-ratio="0.9" data-stellar-vertical-offset="0" data-background=""></div>
-				<div class="container">
-					<div class="blog_b_text text-center">
-						<h2>SpeechBrain Tutorials</h2>
-						<h3>SpeechBrain Basics</h3>
+                <div class="overlay bg-parallax" data-stellar-ratio="0.9" data-stellar-vertical-offset="0" data-background=""></div>
+                <div class="container">
+                    <div class="blog_b_text text-center">
+                        <h2>Tutorials have moved</h2>
+                        <h3><br>Click <a style="color: white; font-weight: bold; text-decoration: underline;" href="https://speechbrain.readthedocs.io/">here</a> if you are not being redirected.</h3>
 
-					</div>
-				</div>
+                    </div>
+                </div>
             </div>
         </section>
-        <!--================End Home Banner Area =================-->	
-	    <div class="alert alert-primary" role="alert" style="text-align: center; font-size: 24px;">
-	    🎉 SpeechBrain 1.0 is out.  <a href="https://colab.research.google.com/drive/1IEPfKRuvJRSjoxu22GZhb3czfVHsAy0s?usp=sharing"><strong> Check out what's new!</strong></a>
-	</div>
+        <!--================End Home Banner Area =================-->
+    <div class="alert alert-primary" role="alert" style="text-align: center; font-size: 24px;">
+        🎉 SpeechBrain 1.0 is out.  <a href="https://colab.research.google.com/drive/1IEPfKRuvJRSjoxu22GZhb3czfVHsAy0s?usp=sharing"><strong> Check out what's new!</strong></a>
+    </div>
         <!--================Blog Categorie Area =================-->
         <section class="blog_categorie_area">
-          <!-- We don't have category for now -->
+            <!-- We don't have category for now -->
         </section>
         <!--================Blog Categorie Area =================-->
 
         <!--================Blog Area =================-->
         <section class="blog_area">
             <div class="container">
-                <div class="row">
-                    <div class="col-md-9">
-                        <div class="blog_left_sidebar">
-                            <article class="row blog_item">
-                               <div class="col-md-3">
-                                   <div class="blog_info text-right">
-                                        <div class="post_tag">
-                                            <a class="active" href="#">SpeechBrain Basics</a>
-                                        </div>
-                                        <ul class="blog_meta list">
-                                            <li><a href="about.html">Ravanelli M.<i class="lnr lnr-user"></i></a></li>
-                                            <li><a href="#">Feb. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                            <li><a href="#">Difficulty: easy<i class="lnr lnr-cog"></i></a></li>
-                                            <li><a href="#">Time: 10min<i class="lnr lnr-hourglass"></i></a></li>
-                                        </ul>
-                                    </div>
-                               </div>
-                                <div class="col-md-9">
-                                  <div class="blog_post">
-                                      <div class="blog_details">
-                                          <h2>Introduction to SpeechBrain</h2>
-                                          <p>SpeechBrain is an open-source all-in-one speech toolkit based on PyTorch.
-                                            It is designed to make the research and development of speech technology easier. Alongside with our <a href="https://speechbrain.readthedocs.io/en/latest/index.html"> documentation</a>
-                                            this tutorial will provide you all the very basic elements needed to start using SpeechBrain for your projects.</p>
-                                          <a href="https://colab.research.google.com/drive/12bg3aUdr9mTfOGqcB5pSMABoIKPgiwcM?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                      </div>
-                                  </div>
-                                </div>
-                            </article>
-                            <article class="row blog_item">
-                               <div class="col-md-3">
-                                   <div class="blog_info text-right">
-                                        <div class="post_tag">
-                                            <a class="active" href="#">SpeechBrain Basics</a>
-                                        </div>
-                                        <ul class="blog_meta list">
-                                            <li><a href="about.html">Ravanelli M.<i class="lnr lnr-user"></i></a></li>
-                                            <li><a href="#">Jan. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                            <li><a href="#">Difficulty: easy<i class="lnr lnr-cog"></i></a></li>
-                                            <li><a href="#">Time: 10min<i class="lnr lnr-hourglass"></i></a></li>
-                                        </ul>
-                                    </div>
-                               </div>
-                                <div class="col-md-9">
-                                  <div class="blog_post">
-                                      <div class="blog_details">
-                                          <h2>What can I do with SpeechBrain?</h2>
-                                          <p>In this tutorial, we provide a high-level description of the speech tasks currently supported by SpeechBrain. 
-					  We also show how to perform inference on speech recognition, speech separation, speaker verification, and other applications.
-					  </p>
-                                          <a href="https://colab.research.google.com/drive/1mhvu5eyEzNBBhNC6sknG-kgD2ZQ6NEyI?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                      </div>
-                                  </div>
-                                </div>
-                            </article>
-                            <article class="row blog_item">
-                               <div class="col-md-3">
-                                   <div class="blog_info text-right">
-                                        <div class="post_tag">
-                                            <a class="active" href="#">SpeechBrain Basics</a>
-                                        </div>
-                                        <ul class="blog_meta list">
-                                            <li><a href="about.html">Plantinga P.<i class="lnr lnr-user"></i></a></li>
-                                            <li><a href="#">Jan. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                            <li><a href="#">Difficulty: easy<i class="lnr lnr-cog"></i></a></li>
-                                            <li><a href="#">Time: 10min<i class="lnr lnr-hourglass"></i></a></li>
-                                        </ul>
-                                    </div>
-                               </div>
-                                <div class="col-md-9">
-                                  <div class="blog_post">
-                                      <div class="blog_details">
-                                          <h2>Brain Class</h2>
-                                          <p>One key component of deep learning is iterating the dataset multiple times and performing parameter updates.
-                                            This process is sometimes called the "training loop" and there are usually many stages to this loop.
-                                            SpeechBrain provides a convenient framework for organizing the training loop, in the form of a class known as the "Brain" class,
-                                            implemented in speechbrain/core.py. In each recipe, we sub-class this class and override the methods for which the default
-                                            implementation doesn't do what is required for that particular recipe.</p>
-                                          <a href="https://colab.research.google.com/drive/1fdqTk4CTXNcrcSVFvaOKzRfLmj4fJfwa?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                      </div>
-                                  </div>
-                                </div>
-                            </article>
-                            <article class="row blog_item">
-                               <div class="col-md-3">
-                                   <div class="blog_info text-right">
-                                        <div class="post_tag">
-                                            <a class="active" href="#">SpeechBrain Basics</a>
-                                        </div>
-                                        <ul class="blog_meta list">
-                                            <li><a href="about.html">Plantinga P.<i class="lnr lnr-user"></i></a></li>
-                                            <li><a href="#">Jan. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                            <li><a href="#">Difficulty: easy<i class="lnr lnr-cog"></i></a></li>
-                                            <li><a href="#">Time: 15min<i class="lnr lnr-hourglass"></i></a></li>
-                                        </ul>
-                                    </div>
-                               </div>
-                                <div class="col-md-9">
-                                  <div class="blog_post">
-                                      <div class="blog_details">
-                                          <h2>HyperPyYAML</h2>
-                                          <p>An essential part of any deep learning pipeline is the definition of hyperparameters and other metadata.
-                                            These data in conjunction with the deep learning algorithms control the various aspects of the pipeline,
-                                            such as model architecture, training, and decoding. At SpeechBrain, we decided that the distinction between
-                                            hyperparameters and learning algorithms ought to be evident in the structure of our toolkit, so we split our
-                                            recipes into two primary files: experiment.py and hyperparams.yaml. The hyperparams.yaml file is in a
-                                            SpeechBrain-developed format, which we call "HyperPyYAML". We chose to extend YAML since it is a highly
-                                            readable format for data serialization. By extending an already useful format, we were able to create an
-                                            expanded definition of hyperparameter, keeping our actual experimental code small and highly readable.</p>
-                                          <a href="https://colab.research.google.com/drive/1Pg9by4b6-8QD2iC0U7Ic3Vxq4GEwEdDz?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                      </div>
-                                  </div>
-                                </div>
-                            </article>
-                            <article class="row blog_item">
-                               <div class="col-md-3">
-                                   <div class="blog_info text-right">
-                                        <div class="post_tag">
-                                            <a class="active" href="#">SpeechBrain Basics</a>
-                                        </div>
-                                        <ul class="blog_meta list">
-                                            <li><a href="about.html">Cornell S. & Rouhe A.<i class="lnr lnr-user"></i></a></li>
-                                            <li><a href="#">Jan. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                            <li><a href="#">Difficulty: medium<i class="lnr lnr-cog"></i></a></li>
-                                            <li><a href="#">Time: 20min<i class="lnr lnr-hourglass"></i></a></li>
-                                        </ul>
-                                    </div>
-                               </div>
-                                <div class="col-md-9">
-                                  <div class="blog_post">
-                                      <div class="blog_details">
-                                          <h2>Data Loading Pipeline</h2>
-                                          <p>Setting up an efficient data loading pipeline is often a tedious task which involves creating the examples,
-                                            defining your torch.utils.data.Dataset class as well as different data sampling and augmentations strategies.
-                                            In SpeechBrain we provide efficient abstractions to simplify this time-consuming process without sacrificing
-                                            flexibility. In fact our data pipeline is built around the Pytorch one.</p>
-                                          <a href="https://colab.research.google.com/drive/1AiVJZhZKwEI4nFGANKXEe-ffZFfvXKwH?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                      </div>
-                                  </div>
-                                </div>
-                            </article>
-                            <article class="row blog_item">
-                               <div class="col-md-3">
-                                   <div class="blog_info text-right">
-                                        <div class="post_tag">
-                                            <a class="active" href="#">SpeechBrain Basics</a>
-                                        </div>
-                                        <ul class="blog_meta list">
-                                            <li><a href="about.html">Rouhe A.<i class="lnr lnr-user"></i></a></li>
-                                            <li><a href="#">Feb. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                            <li><a href="#">Difficulty: easy<i class="lnr lnr-cog"></i></a></li>
-                                            <li><a href="#">Time: 15min<i class="lnr lnr-hourglass"></i></a></li>
-                                        </ul>
-                                    </div>
-                               </div>
-                                <div class="col-md-9">
-                                  <div class="blog_post">
-                                      <div class="blog_details">
-                                          <h2>Checkpointing</h2>
-                                          <p>By checkpointing, we mean saving the model and all the other necessary state information
-                                            (like optimizer parameters, which epoch and which iteration), at a particular point in time.</p>
-                                          <a href="https://colab.research.google.com/drive/1VH7U0oP3CZsUNtChJT2ewbV_q1QX8xre?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                      </div>
-                                  </div>
-                                </div>
-                            </article>
-                            <article class="row blog_item">
-                               <div class="col-md-3">
-                                   <div class="blog_info text-right">
-                                        <div class="post_tag">
-                                            <a class="active" href="#">SpeechBrain Basics</a>
-                                        </div>
-                                        <ul class="blog_meta list">
-                                            <li><a href="about.html">Heba A.<i class="lnr lnr-user"></i></a></li>
-                                            <li><a href="#">Mar. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                            <li><a href="#">Difficulty: easy<i class="lnr lnr-cog"></i></a></li>
-                                            <li><a href="#">Time: 15min<i class="lnr lnr-hourglass"></i></a></li>
-                                        </ul>
-                                    </div>
-                               </div>
-                                <div class="col-md-9">
-                                  <div class="blog_post">
-                                      <div class="blog_details">
-                                          <h2>Multi-GPU Considerations</h2>
-                                          <p>SpeechBrain provides two different methods to use multiple GPUs.
-                                            These solutions follow PyTorch standards and allow for intra- or cross-node training. In this tutorial, the use of Data Parallel (DP) and Distributed Data Parallel (DDP) within SpeechBrain are explained.</p>
-                                          <a href="https://colab.research.google.com/drive/13pBUacPiotw1IvyffvGZ-HrtBr9T6l15?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                      </div>
-                                  </div>
-                                </div>
-                            </article>
-                            <nav class="blog-pagination justify-content-center d-flex">
-		                        <ul class="pagination">
-		                            <li class="page-item">
-		                                <a href="#" class="page-link" aria-label="Previous">
-		                                    <span aria-hidden="true">
-		                                        <span class="lnr lnr-chevron-left"></span>
-		                                    </span>
-		                                </a>
-		                            </li>
-		                            <li class="page-item active"><a href="#" class="page-link">1</a></li>
-		                            <li class="page-item">
-		                                <a href="#" class="page-link" aria-label="Next">
-		                                    <span aria-hidden="true">
-		                                        <span class="lnr lnr-chevron-right"></span>
-		                                    </span>
-		                                </a>
-		                            </li>
-		                        </ul>
-		                    </nav>
-                        </div>
-                    </div>
-                </div>
             </div>
         </section>
         <!--================Blog Area =================-->
 
         <!--================Footer Area =================-->
         <footer class="footer_area p_120">
-          <div class="container">
-            <div class="row footer_inner">
-              <div class="col-lg-5 col-sm-6">
-                <aside class="f_widget ab_widget">
-                  <div class="f_title">
-                    <h3>About Us</h3>
-                  </div>
-                  <p style="text-align:justify">SpeechBrain isn't a company or an association.
+            <div class="container">
+                <div class="row footer_inner">
+                    <div class="col-lg-5 col-sm-6">
+                        <aside class="f_widget ab_widget">
+                            <div class="f_title">
+                                <h3>About Us</h3>
+                            </div>
+                            <p style="text-align:justify">SpeechBrain isn't a company or an association.
                     It is an open-source toolkit and a community created by Dr. Mirco Ravanelli and co-created by Dr. Titouan Parcollet.
                     We aim at making speech technologies more accessible for the community. </p>
-                  <p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
-  Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved</p>
-                </aside>
-              </div>
-              <div class="col-lg-5 col-sm-6">
-                <aside class="f_widget news_widget">
-                  <div class="f_title">
-                    <h3>Opportunities</h3>
-                  </div>
-                  <p>Thanks to our sponsors, we often recruit talented candidates to continue expanding the functionalities of SpeechBrain.
+                            <p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
+Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved</p>
+                        </aside>
+                    </div>
+                    <div class="col-lg-5 col-sm-6">
+                        <aside class="f_widget news_widget">
+                            <div class="f_title">
+                                <h3>Opportunities</h3>
+                            </div>
+                            <p>Thanks to our sponsors, we often recruit talented candidates to continue expanding the functionalities of SpeechBrain.
                     Feel free to contact us at: speechbrainproject@gmail.com</p>
-                </aside>
-              </div>
-              <div class="col-lg-2">
-                <aside class="f_widget social_widget">
-                  <div class="f_title">
-                    <h3>Follow Us</h3>
-                  </div>
-                  <p>Let us be social</p>
-                  <ul class="list">
-                    <li><a href="https://twitter.com/SpeechBrain1"><i class="fa fa-twitter"></i></a></li>
-                  </ul>
-                </aside>
-              </div>
+                        </aside>
+                    </div>
+                    <div class="col-lg-2">
+                        <aside class="f_widget social_widget">
+                            <div class="f_title">
+                                <h3>Follow Us</h3>
+                            </div>
+                            <p>Let us be social</p>
+                            <ul class="list">
+                                <li><a href="https://twitter.com/SpeechBrain1"><i class="fa fa-twitter"></i></a></li>
+                            </ul>
+                        </aside>
+                    </div>
+                </div>
             </div>
-          </div>
         </footer>
         <!--================End Footer Area =================-->
 

--- a/tutorial_classification.html
+++ b/tutorial_classification.html
@@ -4,11 +4,12 @@
         <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <!-- BLOCK INDEX -->
-        <meta name="robots" content="noindex">
-        <!-- BLOCK INDEX -->
         <link rel="icon" href="img/favicon.ico">
-        <title>SpeechBrain</title>
+        
+        <script type="text/javascript">
+            window.location.href = "https://speechbrain.readthedocs.io/";
+        </script>
+        <title>SpeechBrain Tutorials</title>
         <!-- Bootstrap CSS -->
         <link rel="stylesheet" href="css/bootstrap.css">
         <link rel="stylesheet" href="vendors/linericon/style.css">
@@ -26,185 +27,100 @@
         <!--================Header Menu Area =================-->
         <header class="header_area">
             <div class="main_menu">
-            	<nav class="navbar navbar-expand-lg navbar-light">
-					<div class="container box_1620">
-						<!-- Brand and toggle get grouped for better mobile display -->
-						<a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
-						<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-						</button>
-						<!-- Collect the nav links, forms, and other content for toggling -->
-						<div class="collapse navbar-collapse offset" id="navbarSupportedContent">
-							<ul class="nav navbar-nav menu_nav justify-content-center">
-								<li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
-								<li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a>
-								<li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a>
-								<li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/en/latest/index.html">Documentation</a>
-								<li class="nav-item submenu dropdown">
-									<a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Tutorials</a>
-									<ul class="dropdown-menu">
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_basics.html">SpeechBrain Basics</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_advanced.html">SpeechBrain Advanced</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_asr.html">Speech Recognition</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_separation.html">Source Separation</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_enhancement.html">Speech Enhancement</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_classification.html">Speech Classification</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_processing.html">Speech Processing</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_nn.html">Neural Architectures</a></li>
-									</ul>
-								<li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a>
-								</li>
-							</ul>
-						</div>
-					</div>
-            	</nav>
+                <nav class="navbar navbar-expand-lg navbar-light">
+                    <div class="container box_1620">
+                        <!-- Brand and toggle get grouped for better mobile display -->
+                        <a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
+                        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                        </button>
+                        <!-- Collect the nav links, forms, and other content for toggling -->
+                        <div class="collapse navbar-collapse offset" id="navbarSupportedContent">
+                            <ul class="nav navbar-nav menu_nav justify-content-center">
+                                <li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
+                                <li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a></li>
+                                <li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Documentation</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Tutorials</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </nav>
             </div>
         </header>
         <!--================Header Menu Area =================-->
+
         <!--================Home Banner Area =================-->
         <section class="home_banner_area blog_banner">
             <div class="banner_inner d-flex align-items-center">
-            	<div class="overlay bg-parallax" data-stellar-ratio="0.9" data-stellar-vertical-offset="0" data-background=""></div>
-				<div class="container">
-					<div class="blog_b_text text-center">
-						<h2>SpeechBrain Tutorials</h2>
-						<h3>Speech Classification</h3>
+                <div class="overlay bg-parallax" data-stellar-ratio="0.9" data-stellar-vertical-offset="0" data-background=""></div>
+                <div class="container">
+                    <div class="blog_b_text text-center">
+                        <h2>Tutorials have moved</h2>
+                        <h3><br>Click <a style="color: white; font-weight: bold; text-decoration: underline;" href="https://speechbrain.readthedocs.io/">here</a> if you are not being redirected.</h3>
 
-					</div>
-				</div>
+                    </div>
+                </div>
             </div>
         </section>
         <!--================End Home Banner Area =================-->
-	<div class="alert alert-primary" role="alert" style="text-align: center; font-size: 24px;">
-	    🎉 SpeechBrain 1.0 is out.  <a href="https://colab.research.google.com/drive/1IEPfKRuvJRSjoxu22GZhb3czfVHsAy0s?usp=sharing"><strong> Check out what's new!</strong></a>
-	</div>
+    <div class="alert alert-primary" role="alert" style="text-align: center; font-size: 24px;">
+        🎉 SpeechBrain 1.0 is out.  <a href="https://colab.research.google.com/drive/1IEPfKRuvJRSjoxu22GZhb3czfVHsAy0s?usp=sharing"><strong> Check out what's new!</strong></a>
+    </div>
         <!--================Blog Categorie Area =================-->
         <section class="blog_categorie_area">
-          <!-- We don't have category for now -->
+            <!-- We don't have category for now -->
         </section>
         <!--================Blog Categorie Area =================-->
 
         <!--================Blog Area =================-->
         <section class="blog_area">
             <div class="container">
-                <div class="row">
-                    <div class="col-md-9">
-                        <div class="blog_left_sidebar">
-                          <article class="row blog_item">
-                             <div class="col-md-3">
-                                 <div class="blog_info text-right">
-                                      <div class="post_tag">
-                                          <a class="active" href="#">Speech Classification</a>
-                                      </div>
-                                      <ul class="blog_meta list">
-                                          <li><a href="about.html">Ravanelli M.<i class="lnr lnr-user"></i></a></li>
-                                          <li><a href="#">Jan. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                          <li><a href="#">Difficulty: medium<i class="lnr lnr-cog"></i></a></li>
-                                          <li><a href="#">Time: 30min<i class="lnr lnr-hourglass"></i></a></li>
-                                      </ul>
-                                  </div>
-                             </div>
-                              <div class="col-md-9">
-                                  <div class="blog_post">
-                                      <div class="blog_details">
-                                          <h2>Speech Classification from Scratch</h2>
-                                          <p>In this tutorial, we show how to use SpeechBrain to implement an utterance-level speech classifier. 
-					     It might help if you want to develop systems for speaker-id, language-id, emotion recognition, sound classification, keyword spotting, and many 					     	     other tasks.</p>
-                                          <a href="https://colab.research.google.com/drive/1UwisnAjr8nQF3UnrkIJ4abBMAWzVwBMh?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                      </div>
-                                  </div>
-                              </div>
-                          </article>
-                          <article class="row blog_item">
-                             <div class="col-md-3">
-                                 <div class="blog_info text-right">
-                                      <div class="post_tag">
-                                          <a class="active" href="#">Voice Activity Detection</a>
-                                      </div>
-                                      <ul class="blog_meta list">
-                                          <li><a href="about.html">Ravanelli M.<i class="lnr lnr-user"></i></a></li>
-                                          <li><a href="#">Sept. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                          <li><a href="#">Difficulty: easy<i class="lnr lnr-cog"></i></a></li>
-                                          <li><a href="#">Time: 15min<i class="lnr lnr-hourglass"></i></a></li>
-                                      </ul>
-                                  </div>
-                             </div>
-                              <div class="col-md-9">
-                                  <div class="blog_post">
-                                      <div class="blog_details">
-                                          <h2>Voice Activity Detection</h2>
-                                          <p>In this tutorial, we show how to use SpeechBrain for voice activity detection. The tutorial will describe how to train a neural VAD and use it for inference on long audio recordings.</p>
-                                          <a href="https://colab.research.google.com/drive/1Msk2cgSEw-jCuXHmz2_-iOrv-gJHCCxu?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                      </div>
-                                  </div>
-                              </div>
-                          </article>
-                            <nav class="blog-pagination justify-content-center d-flex">
-		                        <ul class="pagination">
-		                            <li class="page-item">
-		                                <a href="#" class="page-link" aria-label="Previous">
-		                                    <span aria-hidden="true">
-		                                        <span class="lnr lnr-chevron-left"></span>
-		                                    </span>
-		                                </a>
-		                            </li>
-		                            <li class="page-item active"><a href="#" class="page-link">1</a></li>
-		                            <li class="page-item">
-		                                <a href="#" class="page-link" aria-label="Next">
-		                                    <span aria-hidden="true">
-		                                        <span class="lnr lnr-chevron-right"></span>
-		                                    </span>
-		                                </a>
-		                            </li>
-		                        </ul>
-		                    </nav>
-                        </div>
-                    </div>
-                </div>
             </div>
         </section>
         <!--================Blog Area =================-->
 
         <!--================Footer Area =================-->
         <footer class="footer_area p_120">
-        	<div class="container">
-        		<div class="row footer_inner">
-        			<div class="col-lg-5 col-sm-6">
-        				<aside class="f_widget ab_widget">
-        					<div class="f_title">
-        						<h3>About Us</h3>
-        					</div>
-        					<p style="text-align:justify">SpeechBrain isn't a company or an association.
+            <div class="container">
+                <div class="row footer_inner">
+                    <div class="col-lg-5 col-sm-6">
+                        <aside class="f_widget ab_widget">
+                            <div class="f_title">
+                                <h3>About Us</h3>
+                            </div>
+                            <p style="text-align:justify">SpeechBrain isn't a company or an association.
                     It is an open-source toolkit and a community created by Dr. Mirco Ravanelli and co-created by Dr. Titouan Parcollet.
                     We aim at making speech technologies more accessible for the community. </p>
-        					<p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
+                            <p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
 Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved</p>
-        				</aside>
-        			</div>
-        			<div class="col-lg-5 col-sm-6">
-        				<aside class="f_widget news_widget">
-        					<div class="f_title">
-        						<h3>Opportunities</h3>
-        					</div>
-        					<p>Thanks to our sponsors, we often recruit talented candidates to continue expanding the functionalities of SpeechBrain.
+                        </aside>
+                    </div>
+                    <div class="col-lg-5 col-sm-6">
+                        <aside class="f_widget news_widget">
+                            <div class="f_title">
+                                <h3>Opportunities</h3>
+                            </div>
+                            <p>Thanks to our sponsors, we often recruit talented candidates to continue expanding the functionalities of SpeechBrain.
                     Feel free to contact us at: speechbrainproject@gmail.com</p>
-        				</aside>
-        			</div>
-        			<div class="col-lg-2">
-        				<aside class="f_widget social_widget">
-        					<div class="f_title">
-        						<h3>Follow Us</h3>
-        					</div>
-        					<p>Let us be social</p>
-        					<ul class="list">
-        						<li><a href="https://twitter.com/SpeechBrain1"><i class="fa fa-twitter"></i></a></li>
-        					</ul>
-        				</aside>
-        			</div>
-        		</div>
-        	</div>
+                        </aside>
+                    </div>
+                    <div class="col-lg-2">
+                        <aside class="f_widget social_widget">
+                            <div class="f_title">
+                                <h3>Follow Us</h3>
+                            </div>
+                            <p>Let us be social</p>
+                            <ul class="list">
+                                <li><a href="https://twitter.com/SpeechBrain1"><i class="fa fa-twitter"></i></a></li>
+                            </ul>
+                        </aside>
+                    </div>
+                </div>
+            </div>
         </footer>
         <!--================End Footer Area =================-->
 

--- a/tutorial_enhancement.html
+++ b/tutorial_enhancement.html
@@ -4,11 +4,12 @@
         <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <!-- BLOCK INDEX -->
-        <meta name="robots" content="noindex">
-        <!-- BLOCK INDEX -->
         <link rel="icon" href="img/favicon.ico">
-        <title>SpeechBrain</title>
+        
+        <script type="text/javascript">
+            window.location.href = "https://speechbrain.readthedocs.io/";
+        </script>
+        <title>SpeechBrain Tutorials</title>
         <!-- Bootstrap CSS -->
         <link rel="stylesheet" href="css/bootstrap.css">
         <link rel="stylesheet" href="vendors/linericon/style.css">
@@ -26,40 +27,28 @@
         <!--================Header Menu Area =================-->
         <header class="header_area">
             <div class="main_menu">
-            	<nav class="navbar navbar-expand-lg navbar-light">
-					<div class="container box_1620">
-						<!-- Brand and toggle get grouped for better mobile display -->
-						<a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
-						<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-						</button>
-						<!-- Collect the nav links, forms, and other content for toggling -->
-						<div class="collapse navbar-collapse offset" id="navbarSupportedContent">
-							<ul class="nav navbar-nav menu_nav justify-content-center">
-								<li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
-								<li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a>
-								<li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a>
-								<li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/en/latest/index.html">Documentation</a>
-								<li class="nav-item submenu dropdown">
-									<a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Tutorials</a>
-									<ul class="dropdown-menu">
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_basics.html">SpeechBrain Basics</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_advanced.html">SpeechBrain Advanced</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_asr.html">Speech Recognition</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_separation.html">Source Separation</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_enhancement.html">Speech Enhancement</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_classification.html">Speech Classification</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_processing.html">Speech Processing</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_nn.html">Neural Architectures</a></li>
-									</ul>
-								<li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a>
-								</li>
-							</ul>
-						</div>
-					</div>
-            	</nav>
+                <nav class="navbar navbar-expand-lg navbar-light">
+                    <div class="container box_1620">
+                        <!-- Brand and toggle get grouped for better mobile display -->
+                        <a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
+                        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                        </button>
+                        <!-- Collect the nav links, forms, and other content for toggling -->
+                        <div class="collapse navbar-collapse offset" id="navbarSupportedContent">
+                            <ul class="nav navbar-nav menu_nav justify-content-center">
+                                <li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
+                                <li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a></li>
+                                <li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Documentation</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Tutorials</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </nav>
             </div>
         </header>
         <!--================Header Menu Area =================-->
@@ -67,122 +56,71 @@
         <!--================Home Banner Area =================-->
         <section class="home_banner_area blog_banner">
             <div class="banner_inner d-flex align-items-center">
-            	<div class="overlay bg-parallax" data-stellar-ratio="0.9" data-stellar-vertical-offset="0" data-background=""></div>
-				<div class="container">
-					<div class="blog_b_text text-center">
-						<h2>SpeechBrain Tutorials</h2>
-						<h3>Speech Enhancement</h3>
+                <div class="overlay bg-parallax" data-stellar-ratio="0.9" data-stellar-vertical-offset="0" data-background=""></div>
+                <div class="container">
+                    <div class="blog_b_text text-center">
+                        <h2>Tutorials have moved</h2>
+                        <h3><br>Click <a style="color: white; font-weight: bold; text-decoration: underline;" href="https://speechbrain.readthedocs.io/">here</a> if you are not being redirected.</h3>
 
-					</div>
-				</div>
+                    </div>
+                </div>
             </div>
         </section>
         <!--================End Home Banner Area =================-->
-	<div class="alert alert-primary" role="alert" style="text-align: center; font-size: 24px;">
-	    🎉 SpeechBrain 1.0 is out.  <a href="https://colab.research.google.com/drive/1IEPfKRuvJRSjoxu22GZhb3czfVHsAy0s?usp=sharing"><strong> Check out what's new!</strong></a>
-	</div>
+    <div class="alert alert-primary" role="alert" style="text-align: center; font-size: 24px;">
+        🎉 SpeechBrain 1.0 is out.  <a href="https://colab.research.google.com/drive/1IEPfKRuvJRSjoxu22GZhb3czfVHsAy0s?usp=sharing"><strong> Check out what's new!</strong></a>
+    </div>
         <!--================Blog Categorie Area =================-->
         <section class="blog_categorie_area">
-          <!-- We don't have category for now -->
+            <!-- We don't have category for now -->
         </section>
         <!--================Blog Categorie Area =================-->
 
         <!--================Blog Area =================-->
         <section class="blog_area">
             <div class="container">
-                <div class="row">
-                    <div class="col-md-9">
-                        <div class="blog_left_sidebar">
-                          <article class="row blog_item">
-                             <div class="col-md-3">
-                                 <div class="blog_info text-right">
-                                      <div class="post_tag">
-                                          <a class="active" href="#">Speech Processing</a>
-                                      </div>
-                                      <ul class="blog_meta list">
-                                          <li><a href="about.html">Plantinga P.<i class="lnr lnr-user"></i></a></li>
-                                          <li><a href="#">Feb. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                          <li><a href="#">Difficulty: medium<i class="lnr lnr-cog"></i></a></li>
-                                          <li><a href="#">Time: 30min<i class="lnr lnr-hourglass"></i></a></li>
-                                      </ul>
-                                  </div>
-                             </div>
-                              <div class="col-md-9">
-                                  <div class="blog_post">
-                                      <div class="blog_details">
-                                          <h2>Speech Enhancement From Scratch</h2>
-                                          <p>So you want to do regression tasks with speech? Look no further, you're in the right place.
-                                            This tutorial will walk you through a basic speech enhancement template with SpeechBrain to
-                                            show all the components needed for making a new recipe.</p>
-                                          <a href="https://colab.research.google.com/drive/18RyiuKupAhwWX7fh3LCatwQGU5eIS3TR?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                      </div>
-                                  </div>
-                              </div>
-                          </article>
-                            <nav class="blog-pagination justify-content-center d-flex">
-		                        <ul class="pagination">
-		                            <li class="page-item">
-		                                <a href="#" class="page-link" aria-label="Previous">
-		                                    <span aria-hidden="true">
-		                                        <span class="lnr lnr-chevron-left"></span>
-		                                    </span>
-		                                </a>
-		                            </li>
-		                            <li class="page-item active"><a href="#" class="page-link">1</a></li>
-		                            <li class="page-item">
-		                                <a href="#" class="page-link" aria-label="Next">
-		                                    <span aria-hidden="true">
-		                                        <span class="lnr lnr-chevron-right"></span>
-		                                    </span>
-		                                </a>
-		                            </li>
-		                        </ul>
-		                    </nav>
-                        </div>
-                    </div>
-                </div>
             </div>
         </section>
         <!--================Blog Area =================-->
 
         <!--================Footer Area =================-->
         <footer class="footer_area p_120">
-        	<div class="container">
-        		<div class="row footer_inner">
-        			<div class="col-lg-5 col-sm-6">
-        				<aside class="f_widget ab_widget">
-        					<div class="f_title">
-        						<h3>About Us</h3>
-        					</div>
-        					<p style="text-align:justify">SpeechBrain isn't a company or an association.
+            <div class="container">
+                <div class="row footer_inner">
+                    <div class="col-lg-5 col-sm-6">
+                        <aside class="f_widget ab_widget">
+                            <div class="f_title">
+                                <h3>About Us</h3>
+                            </div>
+                            <p style="text-align:justify">SpeechBrain isn't a company or an association.
                     It is an open-source toolkit and a community created by Dr. Mirco Ravanelli and co-created by Dr. Titouan Parcollet.
                     We aim at making speech technologies more accessible for the community. </p>
-        					<p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
+                            <p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
 Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved</p>
-        				</aside>
-        			</div>
-        			<div class="col-lg-5 col-sm-6">
-        				<aside class="f_widget news_widget">
-        					<div class="f_title">
-        						<h3>Opportunities</h3>
-        					</div>
-        					<p>Thanks to our sponsors, we often recruit talented candidates to continue expanding the functionalities of SpeechBrain.
+                        </aside>
+                    </div>
+                    <div class="col-lg-5 col-sm-6">
+                        <aside class="f_widget news_widget">
+                            <div class="f_title">
+                                <h3>Opportunities</h3>
+                            </div>
+                            <p>Thanks to our sponsors, we often recruit talented candidates to continue expanding the functionalities of SpeechBrain.
                     Feel free to contact us at: speechbrainproject@gmail.com</p>
-        				</aside>
-        			</div>
-        			<div class="col-lg-2">
-        				<aside class="f_widget social_widget">
-        					<div class="f_title">
-        						<h3>Follow Us</h3>
-        					</div>
-        					<p>Let us be social</p>
-        					<ul class="list">
-        						<li><a href="https://twitter.com/SpeechBrain1"><i class="fa fa-twitter"></i></a></li>
-        					</ul>
-        				</aside>
-        			</div>
-        		</div>
-        	</div>
+                        </aside>
+                    </div>
+                    <div class="col-lg-2">
+                        <aside class="f_widget social_widget">
+                            <div class="f_title">
+                                <h3>Follow Us</h3>
+                            </div>
+                            <p>Let us be social</p>
+                            <ul class="list">
+                                <li><a href="https://twitter.com/SpeechBrain1"><i class="fa fa-twitter"></i></a></li>
+                            </ul>
+                        </aside>
+                    </div>
+                </div>
+            </div>
         </footer>
         <!--================End Footer Area =================-->
 

--- a/tutorial_nn.html
+++ b/tutorial_nn.html
@@ -4,11 +4,12 @@
         <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <!-- BLOCK INDEX -->
-        <meta name="robots" content="noindex">
-        <!-- BLOCK INDEX -->
         <link rel="icon" href="img/favicon.ico">
-        <title>SpeechBrain</title>
+        
+        <script type="text/javascript">
+            window.location.href = "https://speechbrain.readthedocs.io/";
+        </script>
+        <title>SpeechBrain Tutorials</title>
         <!-- Bootstrap CSS -->
         <link rel="stylesheet" href="css/bootstrap.css">
         <link rel="stylesheet" href="vendors/linericon/style.css">
@@ -26,40 +27,28 @@
         <!--================Header Menu Area =================-->
         <header class="header_area">
             <div class="main_menu">
-            	<nav class="navbar navbar-expand-lg navbar-light">
-					<div class="container box_1620">
-						<!-- Brand and toggle get grouped for better mobile display -->
-						<a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
-						<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-						</button>
-						<!-- Collect the nav links, forms, and other content for toggling -->
-						<div class="collapse navbar-collapse offset" id="navbarSupportedContent">
-							<ul class="nav navbar-nav menu_nav justify-content-center">
-								<li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
-								<li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a>
-								<li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a>
-								<li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/en/latest/index.html">Documentation</a>
-								<li class="nav-item submenu dropdown">
-									<a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Tutorials</a>
-									<ul class="dropdown-menu">
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_basics.html">SpeechBrain Basics</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_advanced.html">SpeechBrain Advanced</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_asr.html">Speech Recognition</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_separation.html">Source Separation</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_enhancement.html">Speech Enhancement</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_classification.html">Speech Classification</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_processing.html">Speech Processing</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_nn.html">Neural Architectures</a></li>
-									</ul>
-								<li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a>
-								</li>
-							</ul>
-						</div>
-					</div>
-            	</nav>
+                <nav class="navbar navbar-expand-lg navbar-light">
+                    <div class="container box_1620">
+                        <!-- Brand and toggle get grouped for better mobile display -->
+                        <a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
+                        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                        </button>
+                        <!-- Collect the nav links, forms, and other content for toggling -->
+                        <div class="collapse navbar-collapse offset" id="navbarSupportedContent">
+                            <ul class="nav navbar-nav menu_nav justify-content-center">
+                                <li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
+                                <li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a></li>
+                                <li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Documentation</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Tutorials</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </nav>
             </div>
         </header>
         <!--================Header Menu Area =================-->
@@ -67,180 +56,71 @@
         <!--================Home Banner Area =================-->
         <section class="home_banner_area blog_banner">
             <div class="banner_inner d-flex align-items-center">
-            	<div class="overlay bg-parallax" data-stellar-ratio="0.9" data-stellar-vertical-offset="0" data-background=""></div>
-				<div class="container">
-					<div class="blog_b_text text-center">
-						<h2>SpeechBrain Tutorials</h2>
-						<h3>Neural Architectures</h3>
+                <div class="overlay bg-parallax" data-stellar-ratio="0.9" data-stellar-vertical-offset="0" data-background=""></div>
+                <div class="container">
+                    <div class="blog_b_text text-center">
+                        <h2>Tutorials have moved</h2>
+                        <h3><br>Click <a style="color: white; font-weight: bold; text-decoration: underline;" href="https://speechbrain.readthedocs.io/">here</a> if you are not being redirected.</h3>
 
-					</div>
-				</div>
+                    </div>
+                </div>
             </div>
         </section>
         <!--================End Home Banner Area =================-->
-	<div class="alert alert-primary" role="alert" style="text-align: center; font-size: 24px;">
-	    🎉 SpeechBrain 1.0 is out.  <a href="https://colab.research.google.com/drive/1IEPfKRuvJRSjoxu22GZhb3czfVHsAy0s?usp=sharing"><strong> Check out what's new!</strong></a>
-	</div>
+    <div class="alert alert-primary" role="alert" style="text-align: center; font-size: 24px;">
+        🎉 SpeechBrain 1.0 is out.  <a href="https://colab.research.google.com/drive/1IEPfKRuvJRSjoxu22GZhb3czfVHsAy0s?usp=sharing"><strong> Check out what's new!</strong></a>
+    </div>
         <!--================Blog Categorie Area =================-->
         <section class="blog_categorie_area">
-          <!-- We don't have category for now -->
+            <!-- We don't have category for now -->
         </section>
         <!--================Blog Categorie Area =================-->
 
         <!--================Blog Area =================-->
         <section class="blog_area">
             <div class="container">
-                <div class="row">
-                    <div class="col-md-9">
-                        <div class="blog_left_sidebar">
-
-                          <article class="row blog_item">
-                             <div class="col-md-3">
-                                 <div class="blog_info text-right">
-                                      <div class="post_tag">
-                                          <a class="active" href="#">Neural Architectures</a>
-                                      </div>
-                                      <ul class="blog_meta list">
-                                          <li><a href="about.html">Parcollet T. & Moumen A.<i class="lnr lnr-user"></i></a></li>
-                                          <li><a href="#">Dec. 2022<i class="lnr lnr-calendar-full"></i></a></li>
-                                          <li><a href="#">Difficulty: medium<i class="lnr lnr-cog"></i></a></li>
-                                          <li><a href="#">Time: 20m<i class="lnr lnr-hourglass"></i></a></li>
-                                      </ul>
-                                  </div>
-                             </div>
-                              <div class="col-md-9">
-                                <div class="blog_post">
-                                    <div class="blog_details">
-                                        <h2>Using Wav2Vec 2.0 / HuBERT / WavLM and Whisper from HuggingFace with SpeechBrain</h2>
-                                        <p>This tutorial describes how to combine (use and finetune) pretrained models
-                                          coming from HuggingFace. Any wav2vec 2.0 / HuBERT / WavLM or Whisper model integrated to the transformers interface of HuggingFace can be then plugged to
-                                          SpeechBrain to approach a speech-related task: automatic speech recognition, speaker recognition,
-                                          spoken language understanding ...</p>
-                                        <a href="https://colab.research.google.com/drive/17Hu1pxqhfMisjkSgmM2CnZxfqDyn2hSY?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                    </div>
-                                </div>
-                              </div>
-                          </article>
-
-
-                            <article class="row blog_item">
-                               <div class="col-md-3">
-                                   <div class="blog_info text-right">
-                                        <div class="post_tag">
-                                            <a class="active" href="#">Neural Architectures</a>
-                                        </div>
-                                        <ul class="blog_meta list">
-                                            <li><a href="about.html">Parcollet T.<i class="lnr lnr-user"></i></a></li>
-                                            <li><a href="#">Feb. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                            <li><a href="#">Difficulty: medium<i class="lnr lnr-cog"></i></a></li>
-                                            <li><a href="#">Time: 30min<i class="lnr lnr-hourglass"></i></a></li>
-                                        </ul>
-                                    </div>
-                               </div>
-                                <div class="col-md-9">
-                                  <div class="blog_post">
-                                      <div class="blog_details">
-                                          <h2>Complex and Quaternion Neural networks</h2>
-                                          <p>This tutorial demonstrates how to use the SpeechBrain implementation of complex-valued and quaternion-valued neural networks
-                                            for speech technologies. It covers the basics of highdimensional representations and the associated neural layers :
-                                            Linear, Convolution, Recurrent and Normalisation.</p>
-                                          <a href="https://colab.research.google.com/drive/1H6ObNswTd24ZwkXj3vHRxZcfXBKAsS3q?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                      </div>
-                                  </div>
-                                </div>
-                            </article>
-
-                            <article class="row blog_item">
-                               <div class="col-md-3">
-                                   <div class="blog_info text-right">
-                                        <div class="post_tag">
-                                            <a class="active" href="#">Neural Architectures</a>
-                                        </div>
-                                        <ul class="blog_meta list">
-                                            <li><a href="about.html">Ravanelli M.<i class="lnr lnr-user"></i></a></li>
-                                            <li><a href="#">Feb. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                            <li><a href="#">Difficulty: easy<i class="lnr lnr-cog"></i></a></li>
-                                            <li><a href="#">Time: 30min<i class="lnr lnr-hourglass"></i></a></li>
-                                        </ul>
-                                    </div>
-                               </div>
-                                <div class="col-md-9">
-                                  <div class="blog_post">
-                                      <div class="blog_details">
-                                          <h2>Recurrent Neural Networks and SpeechBrain</h2>
-                                          <p>Recurrent Neural Networks (RNNs) offer a natural way to process sequences.
-                                            This tutorial demonstrates how to use the SpeechBrain implementations of RNNs including LSTMs, GRU, RNN and LiGRU a specific recurrent cell designed
-                                            for speech-related tasks. RNNs are at the core of many sequence to sequence models.</p>
-                                          <a href="https://colab.research.google.com/drive/1CTCzOP016D1c2SVg2jr9UHIz-xvcHgqP?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                      </div>
-                                  </div>
-                                </div>
-                            </article>
-
-                            <nav class="blog-pagination justify-content-center d-flex">
-		                        <ul class="pagination">
-		                            <li class="page-item">
-		                                <a href="#" class="page-link" aria-label="Previous">
-		                                    <span aria-hidden="true">
-		                                        <span class="lnr lnr-chevron-left"></span>
-		                                    </span>
-		                                </a>
-		                            </li>
-		                            <li class="page-item active"><a href="#" class="page-link">1</a></li>
-		                            <li class="page-item">
-		                                <a href="#" class="page-link" aria-label="Next">
-		                                    <span aria-hidden="true">
-		                                        <span class="lnr lnr-chevron-right"></span>
-		                                    </span>
-		                                </a>
-		                            </li>
-		                        </ul>
-		                    </nav>
-                        </div>
-                    </div>
-                </div>
             </div>
         </section>
         <!--================Blog Area =================-->
 
         <!--================Footer Area =================-->
         <footer class="footer_area p_120">
-        	<div class="container">
-        		<div class="row footer_inner">
-        			<div class="col-lg-5 col-sm-6">
-        				<aside class="f_widget ab_widget">
-        					<div class="f_title">
-        						<h3>About Us</h3>
-        					</div>
-        					<p style="text-align:justify">SpeechBrain isn't a company or an association.
+            <div class="container">
+                <div class="row footer_inner">
+                    <div class="col-lg-5 col-sm-6">
+                        <aside class="f_widget ab_widget">
+                            <div class="f_title">
+                                <h3>About Us</h3>
+                            </div>
+                            <p style="text-align:justify">SpeechBrain isn't a company or an association.
                     It is an open-source toolkit and a community created by Dr. Mirco Ravanelli and co-created by Dr. Titouan Parcollet.
                     We aim at making speech technologies more accessible for the community. </p>
-        					<p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
+                            <p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
 Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved</p>
-        				</aside>
-        			</div>
-        			<div class="col-lg-5 col-sm-6">
-        				<aside class="f_widget news_widget">
-        					<div class="f_title">
-        						<h3>Opportunities</h3>
-        					</div>
-        					<p>Thanks to our sponsors, we often recruit talented candidates to continue expanding the functionalities of SpeechBrain.
+                        </aside>
+                    </div>
+                    <div class="col-lg-5 col-sm-6">
+                        <aside class="f_widget news_widget">
+                            <div class="f_title">
+                                <h3>Opportunities</h3>
+                            </div>
+                            <p>Thanks to our sponsors, we often recruit talented candidates to continue expanding the functionalities of SpeechBrain.
                     Feel free to contact us at: speechbrainproject@gmail.com</p>
-        				</aside>
-        			</div>
-        			<div class="col-lg-2">
-        				<aside class="f_widget social_widget">
-        					<div class="f_title">
-        						<h3>Follow Us</h3>
-        					</div>
-        					<p>Let us be social</p>
-        					<ul class="list">
-        						<li><a href="https://twitter.com/SpeechBrain1"><i class="fa fa-twitter"></i></a></li>
-        					</ul>
-        				</aside>
-        			</div>
-        		</div>
-        	</div>
+                        </aside>
+                    </div>
+                    <div class="col-lg-2">
+                        <aside class="f_widget social_widget">
+                            <div class="f_title">
+                                <h3>Follow Us</h3>
+                            </div>
+                            <p>Let us be social</p>
+                            <ul class="list">
+                                <li><a href="https://twitter.com/SpeechBrain1"><i class="fa fa-twitter"></i></a></li>
+                            </ul>
+                        </aside>
+                    </div>
+                </div>
+            </div>
         </footer>
         <!--================End Footer Area =================-->
 

--- a/tutorial_processing.html
+++ b/tutorial_processing.html
@@ -5,7 +5,11 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <link rel="icon" href="img/favicon.ico">
-        <title>SpeechBrain: Speech Processing</title>
+        
+        <script type="text/javascript">
+            window.location.href = "https://speechbrain.readthedocs.io/";
+        </script>
+        <title>SpeechBrain Tutorials</title>
         <!-- Bootstrap CSS -->
         <link rel="stylesheet" href="css/bootstrap.css">
         <link rel="stylesheet" href="vendors/linericon/style.css">
@@ -19,45 +23,32 @@
         <link rel="stylesheet" href="css/responsive.css">
     </head>
     <body>
-      
 
         <!--================Header Menu Area =================-->
         <header class="header_area">
             <div class="main_menu">
-            	<nav class="navbar navbar-expand-lg navbar-light">
-					<div class="container box_1620">
-						<!-- Brand and toggle get grouped for better mobile display -->
-						<a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
-						<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-						</button>
-						<!-- Collect the nav links, forms, and other content for toggling -->
-						<div class="collapse navbar-collapse offset" id="navbarSupportedContent">
-							<ul class="nav navbar-nav menu_nav justify-content-center">
-								<li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
-								<li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a>
-								<li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a>
-								<li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/en/latest/index.html">Documentation</a>
-								<li class="nav-item submenu dropdown">
-									<a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Tutorials</a>
-									<ul class="dropdown-menu">
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_basics.html">SpeechBrain Basics</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_advanced.html">SpeechBrain Advanced</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_asr.html">Speech Recognition</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_separation.html">Source Separation</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_enhancement.html">Speech Enhancement</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_classification.html">Speech Classification</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_processing.html">Speech Processing</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_nn.html">Neural Architectures</a></li>
-									</ul>
-								<li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a>
-								</li>
-							</ul>
-						</div>
-					</div>
-            	</nav>
+                <nav class="navbar navbar-expand-lg navbar-light">
+                    <div class="container box_1620">
+                        <!-- Brand and toggle get grouped for better mobile display -->
+                        <a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
+                        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                        </button>
+                        <!-- Collect the nav links, forms, and other content for toggling -->
+                        <div class="collapse navbar-collapse offset" id="navbarSupportedContent">
+                            <ul class="nav navbar-nav menu_nav justify-content-center">
+                                <li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
+                                <li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a></li>
+                                <li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Documentation</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Tutorials</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </nav>
             </div>
         </header>
         <!--================Header Menu Area =================-->
@@ -65,232 +56,71 @@
         <!--================Home Banner Area =================-->
         <section class="home_banner_area blog_banner">
             <div class="banner_inner d-flex align-items-center">
-            	<div class="overlay bg-parallax" data-stellar-ratio="0.9" data-stellar-vertical-offset="0" data-background=""></div>
-				<div class="container">
-					<div class="blog_b_text text-center">
-						<h2>SpeechBrain Tutorials</h2>
-						<h3>Speech Processing</h3>
+                <div class="overlay bg-parallax" data-stellar-ratio="0.9" data-stellar-vertical-offset="0" data-background=""></div>
+                <div class="container">
+                    <div class="blog_b_text text-center">
+                        <h2>Tutorials have moved</h2>
+                        <h3><br>Click <a style="color: white; font-weight: bold; text-decoration: underline;" href="https://speechbrain.readthedocs.io/">here</a> if you are not being redirected.</h3>
 
-					</div>
-				</div>
+                    </div>
+                </div>
             </div>
         </section>
         <!--================End Home Banner Area =================-->
-	<div class="alert alert-primary" role="alert" style="text-align: center; font-size: 24px;">
-	    🎉 SpeechBrain 1.0 is out.  <a href="https://colab.research.google.com/drive/1IEPfKRuvJRSjoxu22GZhb3czfVHsAy0s?usp=sharing"><strong> Check out what's new!</strong></a>
-	</div>
+    <div class="alert alert-primary" role="alert" style="text-align: center; font-size: 24px;">
+        🎉 SpeechBrain 1.0 is out.  <a href="https://colab.research.google.com/drive/1IEPfKRuvJRSjoxu22GZhb3czfVHsAy0s?usp=sharing"><strong> Check out what's new!</strong></a>
+    </div>
         <!--================Blog Categorie Area =================-->
         <section class="blog_categorie_area">
-          <!-- We don't have category for now -->
+            <!-- We don't have category for now -->
         </section>
         <!--================Blog Categorie Area =================-->
 
         <!--================Blog Area =================-->
         <section class="blog_area">
             <div class="container">
-                <div class="row">
-                    <div class="col-md-9">
-                        <div class="blog_left_sidebar">
-                            <article class="row blog_item">
-                               <div class="col-md-3">
-                                   <div class="blog_info text-right">
-                                        <div class="post_tag">
-                                            <a class="active" href="#">Speech Processing</a>
-                                        </div>
-                                        <ul class="blog_meta list">
-                                            <li><a href="about.html">Ravanelli M.<i class="lnr lnr-user"></i></a></li>
-                                            <li><a href="#">Jan. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                            <li><a href="#">Difficulty: easy<i class="lnr lnr-cog"></i></a></li>
-                                            <li><a href="#">Time: 20min<i class="lnr lnr-hourglass"></i></a></li>
-                                        </ul>
-                                    </div>
-                               </div>
-                                <div class="col-md-9">
-                                    <div class="blog_post">
-                                        <div class="blog_details">
-                                            <h2>Speech Augmentation</h2>
-                                            <p>A popular saying in machine learning is "there is no better data than more data". However, collecting new data can be expensive
-                                              and we must cleverly use the available dataset. One popular technique is called speech augmentation. The idea is to artificially
-                                              corrupt the original speech signals to give the network the "illusion" that we are processing a new signal. This acts as a powerful regularizer,
-                                              that normally helps neural networks improving generalization and thus achieve better performance on test data.</p>
-                                            <a href="https://colab.research.google.com/drive/1JJc4tBhHNXRSDM2xbQ3Z0jdDQUw4S5lr?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                        </div>
-                                    </div>
-                                </div>
-                            </article>
-                            <article class="row blog_item">
-                               <div class="col-md-3">
-                                   <div class="blog_info text-right">
-                                        <div class="post_tag">
-                                            <a class="active" href="#">Speech Processing</a>
-                                        </div>
-                                        <ul class="blog_meta list">
-                                            <li><a href="about.html">Ravanelli M.<i class="lnr lnr-user"></i></a></li>
-                                            <li><a href="#">Jan. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                            <li><a href="#">Difficulty: easy<i class="lnr lnr-cog"></i></a></li>
-                                            <li><a href="#">Time: 20min<i class="lnr lnr-hourglass"></i></a></li>
-                                        </ul>
-                                    </div>
-                               </div>
-                                <div class="col-md-9">
-                                    <div class="blog_post">
-                                        <div class="blog_details">
-                                            <h2>Fourier Transform and Spectrograms</h2>
-                                            <p>In speech and audio processing, the signal in the time-domain is often transformed into another domain.
-                                              Ok, but why do we need to transform an audio signal? Some speech characteristics/patterns of the signal (e.g, pitch, formats)
-                                              might not be very evident when looking at the audio in the time-domain. With properly designed transformations,
-                                              it might be easier to extract the needed information from the signal itself. The most popular transformation is the
-                                              Fourier Transform, which turns the time-domain signal into an equivalent representation in the frequency domain.
-                                              In the following sections, we will describe the Fourier transforms along with other related transformations such as
-                                              Short-Term Fourier Transform (STFT) and spectrograms.</p>
-                                            <a href="https://colab.research.google.com/drive/18IgBv3Ip0rWXjYoZywttSmW7Y2AIK1vJ?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                        </div>
-                                    </div>
-                                </div>
-                            </article>
-                            <article class="row blog_item">
-                               <div class="col-md-3">
-                                   <div class="blog_info text-right">
-                                        <div class="post_tag">
-                                            <a class="active" href="#">Speech Processing</a>
-                                        </div>
-                                        <ul class="blog_meta list">
-                                            <li><a href="about.html">Ravanelli M.<i class="lnr lnr-user"></i></a></li>
-                                            <li><a href="#">Jan. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                            <li><a href="#">Difficulty: easy<i class="lnr lnr-cog"></i></a></li>
-                                            <li><a href="#">Time: 20min<i class="lnr lnr-hourglass"></i></a></li>
-                                        </ul>
-                                    </div>
-                               </div>
-                                <div class="col-md-9">
-                                    <div class="blog_post">
-                                        <div class="blog_details">
-                                            <h2>Speech Features</h2>
-                                            <p>Speech is a very high-dimensional signal. For instance, when the sampling frequency is 16 kHz,
-                                              we have 16000 samples for each second. Working with such very high dimensional data can be critical from a machine learning perspective.
-                                              The goal of feature extraction is to find more compact ways to represent speech.</p>
-                                            <a href="https://colab.research.google.com/drive/1CI72Xyay80mmmagfLaIIeRoDgswWHT_g?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                        </div>
-                                    </div>
-                                </div>
-                            </article>
-                            <article class="row blog_item">
-                               <div class="col-md-3">
-                                   <div class="blog_info text-right">
-                                        <div class="post_tag">
-                                            <a class="active" href="#">Speech Processing</a>
-                                        </div>
-                                        <ul class="blog_meta list">
-                                            <li><a href="about.html">Ravanelli M.<i class="lnr lnr-user"></i></a></li>
-                                            <li><a href="#">Feb. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                            <li><a href="#">Difficulty: medium<i class="lnr lnr-cog"></i></a></li>
-                                            <li><a href="#">Time: 20min<i class="lnr lnr-hourglass"></i></a></li>
-                                        </ul>
-                                    </div>
-                               </div>
-                                <div class="col-md-9">
-                                    <div class="blog_post">
-                                        <div class="blog_details">
-                                            <h2>Environmental corruption</h2>
-                                            <p>In realistic speech processing applications, the signal recorded by the microphone is corrupted by noise and reverberation.
-                                              This is particularly harmful in distant-talking (far-field) scenarios, where the speaker and the reference microphone are distant
-                                              (think about popular devices such as Google Home, Amazon Echo, Kinect, and similar devices).</p>
-                                            <a href="https://colab.research.google.com/drive/1mAimqZndq0BwQj63VcDTr6_uCMC6i6Un?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                        </div>
-                                    </div>
-                                </div>
-                            </article>
-                            <article class="row blog_item">
-                               <div class="col-md-3">
-                                   <div class="blog_info text-right">
-                                        <div class="post_tag">
-                                            <a class="active" href="#">Speech Processing</a>
-                                        </div>
-                                        <ul class="blog_meta list">
-                                            <li><a href="about.html">Grondin F. & Aris W.<i class="lnr lnr-user"></i></a></li>
-                                            <li><a href="#">Jan. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                            <li><a href="#">Difficulty: medium<i class="lnr lnr-cog"></i></a></li>
-                                            <li><a href="#">Time: 20min<i class="lnr lnr-hourglass"></i></a></li>
-                                        </ul>
-                                    </div>
-                               </div>
-                                <div class="col-md-9">
-                                    <div class="blog_post">
-                                        <div class="blog_details">
-                                            <h2>Multi-microphone Beamforming</h2>
-                                            <p>Using a microphone array can be very handy to improve the signal quality
-                                              (e.g. reduce reverberation and noise) prior to performing speech recognition tasks.
-                                              Microphone arrays can also estimate the direction of arrival of a sound source, and this information can later
-                                              be used to "listen" in the direction of the source of interest.</p>
-                                            <a href="https://colab.research.google.com/drive/1UVoYDUiIrwMpBTghQPbA6rC1mc9IBzi6?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                        </div>
-                                    </div>
-                                </div>
-                            </article>
-                            <nav class="blog-pagination justify-content-center d-flex">
-		                        <ul class="pagination">
-		                            <li class="page-item">
-		                                <a href="#" class="page-link" aria-label="Previous">
-		                                    <span aria-hidden="true">
-		                                        <span class="lnr lnr-chevron-left"></span>
-		                                    </span>
-		                                </a>
-		                            </li>
-		                            <li class="page-item active"><a href="#" class="page-link">1</a></li>
-		                            <li class="page-item">
-		                                <a href="#" class="page-link" aria-label="Next">
-		                                    <span aria-hidden="true">
-		                                        <span class="lnr lnr-chevron-right"></span>
-		                                    </span>
-		                                </a>
-		                            </li>
-		                        </ul>
-		                    </nav>
-                        </div>
-                    </div>
-                </div>
             </div>
         </section>
         <!--================Blog Area =================-->
 
         <!--================Footer Area =================-->
         <footer class="footer_area p_120">
-        	<div class="container">
-        		<div class="row footer_inner">
-        			<div class="col-lg-5 col-sm-6">
-        				<aside class="f_widget ab_widget">
-        					<div class="f_title">
-        						<h3>About Us</h3>
-        					</div>
-        					<p style="text-align:justify">SpeechBrain isn't a company or an association.
+            <div class="container">
+                <div class="row footer_inner">
+                    <div class="col-lg-5 col-sm-6">
+                        <aside class="f_widget ab_widget">
+                            <div class="f_title">
+                                <h3>About Us</h3>
+                            </div>
+                            <p style="text-align:justify">SpeechBrain isn't a company or an association.
                     It is an open-source toolkit and a community created by Dr. Mirco Ravanelli and co-created by Dr. Titouan Parcollet.
                     We aim at making speech technologies more accessible for the community. </p>
-        					<p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
+                            <p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
 Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved</p>
-        				</aside>
-        			</div>
-        			<div class="col-lg-5 col-sm-6">
-        				<aside class="f_widget news_widget">
-        					<div class="f_title">
-        						<h3>Opportunities</h3>
-        					</div>
-        					<p>Thanks to our sponsors, we often recruit talented candidates to continue expanding the functionalities of SpeechBrain.
+                        </aside>
+                    </div>
+                    <div class="col-lg-5 col-sm-6">
+                        <aside class="f_widget news_widget">
+                            <div class="f_title">
+                                <h3>Opportunities</h3>
+                            </div>
+                            <p>Thanks to our sponsors, we often recruit talented candidates to continue expanding the functionalities of SpeechBrain.
                     Feel free to contact us at: speechbrainproject@gmail.com</p>
-        				</aside>
-        			</div>
-        			<div class="col-lg-2">
-        				<aside class="f_widget social_widget">
-        					<div class="f_title">
-        						<h3>Follow Us</h3>
-        					</div>
-        					<p>Let us be social</p>
-        					<ul class="list">
-        						<li><a href="https://twitter.com/SpeechBrain1"><i class="fa fa-twitter"></i></a></li>
-        					</ul>
-        				</aside>
-        			</div>
-        		</div>
-        	</div>
+                        </aside>
+                    </div>
+                    <div class="col-lg-2">
+                        <aside class="f_widget social_widget">
+                            <div class="f_title">
+                                <h3>Follow Us</h3>
+                            </div>
+                            <p>Let us be social</p>
+                            <ul class="list">
+                                <li><a href="https://twitter.com/SpeechBrain1"><i class="fa fa-twitter"></i></a></li>
+                            </ul>
+                        </aside>
+                    </div>
+                </div>
+            </div>
         </footer>
         <!--================End Footer Area =================-->
 

--- a/tutorial_separation.html
+++ b/tutorial_separation.html
@@ -4,11 +4,12 @@
         <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <!-- BLOCK INDEX -->
-        <meta name="robots" content="noindex">
-        <!-- BLOCK INDEX -->
         <link rel="icon" href="img/favicon.ico">
-        <title>SpeechBrain</title>
+        
+        <script type="text/javascript">
+            window.location.href = "https://speechbrain.readthedocs.io/";
+        </script>
+        <title>SpeechBrain Tutorials</title>
         <!-- Bootstrap CSS -->
         <link rel="stylesheet" href="css/bootstrap.css">
         <link rel="stylesheet" href="vendors/linericon/style.css">
@@ -26,40 +27,28 @@
         <!--================Header Menu Area =================-->
         <header class="header_area">
             <div class="main_menu">
-            	<nav class="navbar navbar-expand-lg navbar-light">
-					<div class="container box_1620">
-						<!-- Brand and toggle get grouped for better mobile display -->
-						<a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
-						<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-						</button>
-						<!-- Collect the nav links, forms, and other content for toggling -->
-						<div class="collapse navbar-collapse offset" id="navbarSupportedContent">
-							<ul class="nav navbar-nav menu_nav justify-content-center">
-								<li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
-								<li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a>
-								<li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a>
-								<li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/en/latest/index.html">Documentation</a>
-								<li class="nav-item submenu dropdown">
-									<a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Tutorials</a>
-									<ul class="dropdown-menu">
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_basics.html">SpeechBrain Basics</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_advanced.html">SpeechBrain Advanced</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_asr.html">Speech Recognition</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_separation.html">Source Separation</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_enhancement.html">Speech Enhancement</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_classification.html">Speech Classification</a></li>
-                    							<li class="nav-item"><a class="nav-link" href="tutorial_processing.html">Speech Processing</a></li>
-		    							<li class="nav-item"><a class="nav-link" href="tutorial_nn.html">Neural Architectures</a></li>
-									</ul>
-								<li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a>
-								</li>
-							</ul>
-						</div>
-					</div>
-            	</nav>
+                <nav class="navbar navbar-expand-lg navbar-light">
+                    <div class="container box_1620">
+                        <!-- Brand and toggle get grouped for better mobile display -->
+                        <a class="navbar-brand logo_h" href="index.html"><img src="img/speechbrain-horiz-logo.svg" width="175px" alt=""></a>
+                        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                            <span class="icon-bar"></span>
+                        </button>
+                        <!-- Collect the nav links, forms, and other content for toggling -->
+                        <div class="collapse navbar-collapse offset" id="navbarSupportedContent">
+                            <ul class="nav navbar-nav menu_nav justify-content-center">
+                                <li class="nav-item active"><a class="nav-link" href="index.html">Home</a></li>
+                                <li class="nav-item"><a class="nav-link" href="about.html">About SpeechBrain</a></li>
+                                <li class="nav-item"><a class="nav-link" href="contributing.html">Contributing</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Documentation</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://speechbrain.readthedocs.io/">Tutorials</a></li>
+                                <li class="nav-item"><a class="nav-link" href="https://github.com/speechbrain/benchmarks">Benchmarks</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </nav>
             </div>
         </header>
         <!--================Header Menu Area =================-->
@@ -67,121 +56,71 @@
         <!--================Home Banner Area =================-->
         <section class="home_banner_area blog_banner">
             <div class="banner_inner d-flex align-items-center">
-            	<div class="overlay bg-parallax" data-stellar-ratio="0.9" data-stellar-vertical-offset="0" data-background=""></div>
-				<div class="container">
-					<div class="blog_b_text text-center">
-						<h2>SpeechBrain Tutorials</h2>
-						<h3>Source Separation</h3>
+                <div class="overlay bg-parallax" data-stellar-ratio="0.9" data-stellar-vertical-offset="0" data-background=""></div>
+                <div class="container">
+                    <div class="blog_b_text text-center">
+                        <h2>Tutorials have moved</h2>
+                        <h3><br>Click <a style="color: white; font-weight: bold; text-decoration: underline;" href="https://speechbrain.readthedocs.io/">here</a> if you are not being redirected.</h3>
 
-					</div>
-				</div>
+                    </div>
+                </div>
             </div>
         </section>
         <!--================End Home Banner Area =================-->
-	<div class="alert alert-primary" role="alert" style="text-align: center; font-size: 24px;">
-	    🎉 SpeechBrain 1.0 is out.  <a href="https://colab.research.google.com/drive/1IEPfKRuvJRSjoxu22GZhb3czfVHsAy0s?usp=sharing"><strong> Check out what's new!</strong></a>
-	</div>
+    <div class="alert alert-primary" role="alert" style="text-align: center; font-size: 24px;">
+        🎉 SpeechBrain 1.0 is out.  <a href="https://colab.research.google.com/drive/1IEPfKRuvJRSjoxu22GZhb3czfVHsAy0s?usp=sharing"><strong> Check out what's new!</strong></a>
+    </div>
         <!--================Blog Categorie Area =================-->
         <section class="blog_categorie_area">
-          <!-- We don't have category for now -->
+            <!-- We don't have category for now -->
         </section>
         <!--================Blog Categorie Area =================-->
 
         <!--================Blog Area =================-->
         <section class="blog_area">
             <div class="container">
-                <div class="row">
-                    <div class="col-md-9">
-                        <div class="blog_left_sidebar">
-                          <article class="row blog_item">
-                             <div class="col-md-3">
-                                 <div class="blog_info text-right">
-                                      <div class="post_tag">
-                                          <a class="active" href="#">Source Separation</a>
-                                      </div>
-                                      <ul class="blog_meta list">
-                                          <li><a href="about.html">Subakan C.<i class="lnr lnr-user"></i></a></li>
-                                          <li><a href="#">Jan. 2021<i class="lnr lnr-calendar-full"></i></a></li>
-                                          <li><a href="#">Difficulty: medium<i class="lnr lnr-cog"></i></a></li>
-                                          <li><a href="#">Time: 30min<i class="lnr lnr-hourglass"></i></a></li>
-                                      </ul>
-                                  </div>
-                             </div>
-                              <div class="col-md-9">
-                                  <div class="blog_post">
-                                      <div class="blog_details">
-                                          <h2>Source Separation</h2>
-                                          <p>In source separation, the goal is to be able to separate out the sources from an observed mixture signal
-                                            which consists of superposition of several sources. In this tutorial, we cover few examples of performing source separation with SpeechBrain.</p>
-                                          <a href="https://colab.research.google.com/drive/1YxsMW1KNqP1YihNUcfrjy0zUp7FhNNhN?usp=sharing" class="blog_btn">Open in Google Colab</a>
-                                      </div>
-                                  </div>
-                              </div>
-                          </article>
-                            <nav class="blog-pagination justify-content-center d-flex">
-		                        <ul class="pagination">
-		                            <li class="page-item">
-		                                <a href="#" class="page-link" aria-label="Previous">
-		                                    <span aria-hidden="true">
-		                                        <span class="lnr lnr-chevron-left"></span>
-		                                    </span>
-		                                </a>
-		                            </li>
-		                            <li class="page-item active"><a href="#" class="page-link">1</a></li>
-		                            <li class="page-item">
-		                                <a href="#" class="page-link" aria-label="Next">
-		                                    <span aria-hidden="true">
-		                                        <span class="lnr lnr-chevron-right"></span>
-		                                    </span>
-		                                </a>
-		                            </li>
-		                        </ul>
-		                    </nav>
-                        </div>
-                    </div>
-                </div>
             </div>
         </section>
         <!--================Blog Area =================-->
 
         <!--================Footer Area =================-->
         <footer class="footer_area p_120">
-        	<div class="container">
-        		<div class="row footer_inner">
-        			<div class="col-lg-5 col-sm-6">
-        				<aside class="f_widget ab_widget">
-        					<div class="f_title">
-        						<h3>About Us</h3>
-        					</div>
-        					<p style="text-align:justify">SpeechBrain isn't a company or an association.
+            <div class="container">
+                <div class="row footer_inner">
+                    <div class="col-lg-5 col-sm-6">
+                        <aside class="f_widget ab_widget">
+                            <div class="f_title">
+                                <h3>About Us</h3>
+                            </div>
+                            <p style="text-align:justify">SpeechBrain isn't a company or an association.
                     It is an open-source toolkit and a community created by Dr. Mirco Ravanelli and co-created by Dr. Titouan Parcollet.
                     We aim at making speech technologies more accessible for the community. </p>
-        					<p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
+                            <p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
 Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved</p>
-        				</aside>
-        			</div>
-        			<div class="col-lg-5 col-sm-6">
-        				<aside class="f_widget news_widget">
-        					<div class="f_title">
-        						<h3>Opportunities</h3>
-        					</div>
-        					<p>Thanks to our sponsors, we often recruit talented candidates to continue expanding the functionalities of SpeechBrain.
+                        </aside>
+                    </div>
+                    <div class="col-lg-5 col-sm-6">
+                        <aside class="f_widget news_widget">
+                            <div class="f_title">
+                                <h3>Opportunities</h3>
+                            </div>
+                            <p>Thanks to our sponsors, we often recruit talented candidates to continue expanding the functionalities of SpeechBrain.
                     Feel free to contact us at: speechbrainproject@gmail.com</p>
-        				</aside>
-        			</div>
-        			<div class="col-lg-2">
-        				<aside class="f_widget social_widget">
-        					<div class="f_title">
-        						<h3>Follow Us</h3>
-        					</div>
-        					<p>Let us be social</p>
-        					<ul class="list">
-        						<li><a href="https://twitter.com/SpeechBrain1"><i class="fa fa-twitter"></i></a></li>
-        					</ul>
-        				</aside>
-        			</div>
-        		</div>
-        	</div>
+                        </aside>
+                    </div>
+                    <div class="col-lg-2">
+                        <aside class="f_widget social_widget">
+                            <div class="f_title">
+                                <h3>Follow Us</h3>
+                            </div>
+                            <p>Let us be social</p>
+                            <ul class="list">
+                                <li><a href="https://twitter.com/SpeechBrain1"><i class="fa fa-twitter"></i></a></li>
+                            </ul>
+                        </aside>
+                    </div>
+                </div>
+            </div>
         </footer>
         <!--================End Footer Area =================-->
 


### PR DESCRIPTION
See: https://github.com/speechbrain/speechbrain/pull/2685

Should be merged when the main repo PR is merged, but not before. Not a big deal if there's a bit of a delay between the two merges as the main repo PR doesn't invalidate any existing links.

Tutorial pages are not removed (to avoid 404s) but now redirect to the documentation. The documentation landing page will make tutorials very obvious to access even if there is no dedicated tutorials page.